### PR TITLE
feat(vocabulary): add vocabulary & category models, migrations, controllers, and API endpoints

### DIFF
--- a/app/Helpers/ValidationHelper.php
+++ b/app/Helpers/ValidationHelper.php
@@ -48,4 +48,45 @@ class ValidationHelper
             ],
         );
     }
+
+    public static function vocabularyCategory($data)
+    {
+        return Validator::make(
+            $data,
+            [
+                'name' => 'required|string|max:255',
+                'color_code' => 'nullable|string|max:20',
+            ],
+            [
+                'name.required' => 'Category name is required',
+                'name.string' => 'Category name must be a string',
+                'color_code.string' => 'Color code must be a string',
+            ],
+        );
+    }
+
+    public static function vocabulary($data)
+    {
+        return Validator::make(
+            $data,
+            [
+                // 'teacher_id' => 'required|exists:users,id',
+                'category_id' => 'required|exists:vocabulary_categories,id',
+                'word' => 'required|string|max:255',
+                'translation' => 'required|string|max:255',
+                'spelling' => 'nullable|string|max:255',
+                'explanation' => 'nullable|string',
+                'audio_file_path' => 'nullable|string|max:255',
+                'is_public' => 'boolean',
+            ],
+            [
+                // 'teacher_id.required' => 'Teacher ID is required',
+                // 'teacher_id.exists' => 'Teacher ID not found',
+                'category_id.required' => 'Category ID is required',
+                'category_id.exists' => 'Category ID not found',
+                'word.required' => 'Word is required',
+                'translation.required' => 'Translation is required',
+            ],
+        );
+    }
 }

--- a/app/Http/Controllers/VocabularyCategoryController.php
+++ b/app/Http/Controllers/VocabularyCategoryController.php
@@ -1,0 +1,302 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\VocabularyCategory;
+use App\Helpers\ValidationHelper;
+use DB;
+
+class VocabularyCategoryController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/api/vocab/categories",
+     *     tags={"Vocabulary Categories"},
+     *     summary="Get all vocabulary categories",
+     *     description="Returns a list of all vocabulary categories.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of vocabulary categories",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="name", type="string", example="nouns"),
+     *                 @OA\Property(property="color_code", type="string", example="#FF0000"),
+     *                 @OA\Property(property="created_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function index()
+    {
+        $vocabularyCategories = VocabularyCategory::all();
+        return response()->json($vocabularyCategories, 200);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/vocab/categories/create",
+     *     tags={"Vocabulary Categories"},
+     *     summary="Create a new vocabulary category",
+     *     description="Adds a new vocabulary category. Requires authentication.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="nouns"),
+     *             @OA\Property(property="color_code", type="string", example="#FF0000")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Category created successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="name", type="string", example="nouns"),
+     *                 @OA\Property(property="color_code", type="string", example="#FF0000"),
+     *                 @OA\Property(property="created_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=422, description="Validation failed"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
+     */
+    public function store(Request $request)
+    {
+        DB::beginTransaction();
+        try{
+            $validator = ValidationHelper::vocabularyCategory($request->all());
+            if ($validator->fails()) {
+                return response()->json(['errors' => $validator->errors()], 422);
+            }
+
+            $existingCategory = VocabularyCategory::where('name', $request->name)->first();
+            if ($existingCategory) {
+                return response()->json(['error' => 'Category name already exists'], 422);
+            }
+
+            $category = VocabularyCategory::create($validator->validated());
+
+            DB::commit();
+            return response()->json(['message' => 'Category created successfully', 'data' => $category], 201);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Server error' ,'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/vocab/categories/{id}",
+     *     tags={"Vocabulary Categories"},
+     *     summary="Get a specific vocabulary category",
+     *     description="Retrieve details of a specific category by its ID.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the category",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="string", example="uuid-string"),
+     *             @OA\Property(property="name", type="string", example="nouns"),
+     *             @OA\Property(property="color_code", type="string", example="#FF0000"),
+     *             @OA\Property(property="created_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *             @OA\Property(property="updated_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Category not found")
+     * )
+     */
+    public function show($id)
+    {
+        $category = VocabularyCategory::findOrFail($id);
+        if (!$category) {
+            return response()->json(['error' => 'Category not found'], 404);
+        }
+        return response()->json($category, 200);
+    }
+
+    /**
+     * @OA\Patch(
+     *     path="/api/vocab/categories/update/{id}",
+     *     tags={"Vocabulary Categories"},
+     *     summary="Update an existing vocabulary category",
+     *     description="Update a vocabulary category's name or description.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the category",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"name"},
+     *             @OA\Property(property="name", type="string", example="verb"),
+     *             @OA\Property(property="color_code", type="string", example="#FFA000")
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Category created successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="name", type="string", example="verb"),
+     *                 @OA\Property(property="color_code", type="string", example="#FFA000"),
+     *                 @OA\Property(property="created_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-07-15T07:19:54.000000Z"),
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Category not found"),
+     *     @OA\Response(response=422, description="Validation failed"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
+     */
+    public function update(Request $request, $id)
+    {
+        $category = VocabularyCategory::findOrFail($id);
+        if (!$category) {
+            return response()->json(['error' => 'Category not found'], 404);
+        }
+
+        DB::beginTransaction();
+        try{
+            $validator = ValidationHelper::vocabularyCategory($request->all());
+            if ($validator->fails()) {
+                return response()->json(['errors' => $validator->errors()], 422);
+            }
+
+            $category->update($validator->validated());
+
+            DB::commit();
+            return response()->json(['message' => 'Category updated successfully', 'data' => $category], 200);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Server error' ,'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/vocabulary-categories/{id}",
+     *     tags={"Vocabulary Categories"},
+     *     summary="Delete a vocabulary category",
+     *     description="Delete a category by its UUID.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the category",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Category deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Category deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Category not found")
+     * )
+     */
+    public function destroy($id)
+    {
+        $category = VocabularyCategory::findOrFail($id);
+        if (!$category) {
+            return response()->json(['error' => 'Category not found'], 404);
+        }
+
+        $category->delete();
+        return response()->json(['message' => 'Category deleted successfully'], 200);
+    }
+}

--- a/app/Http/Controllers/VocabularyController.php
+++ b/app/Http/Controllers/VocabularyController.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use App\Models\Vocabulary;
+use App\Helpers\ValidationHelper;
+use DB;
+
+class VocabularyController extends Controller
+{
+    /**
+     * @OA\Get(
+     *     path="/api/vocab/vocabularies",
+     *     tags={"Vocabulary"},
+     *     summary="Get all vocabularies",
+     *     description="Returns a list of all vocabulary entries.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="List of vocabulary entries",
+     *         @OA\JsonContent(
+     *             type="array",
+     *             @OA\Items(
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="teacher_id", type="string", example="uuid-teacher"),
+     *                 @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *                 @OA\Property(property="word", type="string", example="Elephant"),
+     *                 @OA\Property(property="translation", type="string", example="Gajah"),
+     *                 @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *                 @OA\Property(property="explanation", type="string", example="A large mammal with trunk."),
+     *                 @OA\Property(property="audio_file_path", type="string", example="audio/elephant.mp3"),
+     *                 @OA\Property(property="is_public", type="boolean", example=1),
+     *                 @OA\Property(property="created_at", type="string", example="2025-08-01T10:00:00Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-08-01T10:00:00Z"),
+     *             )
+     *         )
+     *     )
+     * )
+     */
+    public function index()
+    {
+        $vocabularies = Vocabulary::all();
+        return response()->json($vocabularies, 200);
+    }
+
+    /**
+     * @OA\Post(
+     *     path="/api/vocab/create",
+     *     tags={"Vocabulary"},
+     *     summary="Create a new vocabulary entry",
+     *     description="Adds a new vocabulary entry to the system.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             required={"category_id","word","translation","is_public"},
+     *             @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *             @OA\Property(property="word", type="string", example="Elephant"),
+     *             @OA\Property(property="translation", type="string", example="Gajah"),
+     *             @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *             @OA\Property(property="explanation", type="string", example="A large mammal with trunk."),
+     *             @OA\Property(property="audio_file_path", type="string", example="audio/elephant.mp3"),
+     *             @OA\Property(property="is_public", type="boolean", example=1)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Vocabulary created successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Vocabulary created successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="teacher_id", type="string", example="uuid-teacher"),
+     *                 @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *                 @OA\Property(property="word", type="string", example="Elephant"),
+     *                 @OA\Property(property="translation", type="string", example="Gajah"),
+     *                 @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *                 @OA\Property(property="explanation", type="string", example="A large mammal with trunk."),
+     *                 @OA\Property(property="audio_file_path", type="string", example="audio/elephant.mp3"),
+     *                 @OA\Property(property="is_public", type="boolean", example=1),
+     *                 @OA\Property(property="created_at", type="string", example="2025-08-01T10:00:00Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-08-01T10:00:00Z")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=422, description="Validation failed"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
+     */
+    public function store(Request $request)
+    {
+        DB::beginTransaction();
+        try{
+            $validator = ValidationHelper::vocabulary($request->all());
+            if ($validator->fails()) {
+                return response()->json(['errors' => $validator->errors()], 422);
+            }
+
+            $existingVocabulary = Vocabulary::where('word', $request->word)->first();
+            if ($existingVocabulary) {
+                return response()->json(['error' => 'Vocabulary word already exists'], 422);
+            }
+
+            $data = $validator->validated();
+
+            $vocabulary = Vocabulary::create([
+                'teacher_id' => auth()->user()->id,
+                'category_id' => $data['category_id'],
+                'word' => $data['word'],
+                'translation' => $data['translation'],
+                'spelling' => $data['spelling'],
+                'explanation' => $data['explanation'],
+                'audio_file_path' => isset($data['audio_file_path']),
+                'is_public' => $data['is_public'],
+            ]);
+
+            DB::commit();
+            return response()->json(['message' => 'Vocabulary created successfully', 'data' => $vocabulary], 201);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Server error' ,'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * @OA\Get(
+     *     path="/api/vocab/{id}",
+     *     tags={"Vocabulary"},
+     *     summary="Get a specific vocabulary entry",
+     *     description="Retrieve details of a vocabulary entry by its ID.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the vocabulary",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Vocabulary retrieved successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="id", type="string", example="uuid-string"),
+     *             @OA\Property(property="teacher_id", type="string", example="uuid-teacher"),
+     *             @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *             @OA\Property(property="word", type="string", example="Elephant"),
+     *             @OA\Property(property="translation", type="string", example="Gajah"),
+     *             @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *             @OA\Property(property="explanation", type="string", example="A large mammal with trunk."),
+     *             @OA\Property(property="audio_file_path", type="string", example="audio/elephant.mp3"),
+     *             @OA\Property(property="is_public", type="boolean", example=1),
+     *             @OA\Property(property="created_at", type="string", example="2025-08-01T10:00:00Z"),
+     *             @OA\Property(property="updated_at", type="string", example="2025-08-01T10:00:00Z")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Vocabulary not found")
+     * )
+     */
+    public function show($id)
+    {
+        $vocabulary = Vocabulary::findOrFail($id);
+        if (!$vocabulary) {
+            return response()->json(['error' => 'Vocabulary not found'], 404);
+        }
+        return response()->json($vocabulary, 200);
+    }
+
+    /**
+     * @OA\Patch(
+     *     path="/api/vocab/update/{id}",
+     *     tags={"Vocabulary"},
+     *     summary="Update a vocabulary entry",
+     *     description="Updates an existing vocabulary entry.
+     *     **Note:** If using form-data or POST, include params `_method=PATCH`.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the vocabulary",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(
+     *             @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *             @OA\Property(property="word", type="string", example="Elephant Updated"),
+     *             @OA\Property(property="translation", type="string", example="Gajah Besar"),
+     *             @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *             @OA\Property(property="explanation", type="string", example="Updated explanation"),
+     *             @OA\Property(property="audio_file_path", type="string", example="audio/elephant-new.mp3"),
+     *             @OA\Property(property="is_public", type="boolean", example=0)
+     *         )
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Vocabulary updated successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Vocabulary updated successfully"),
+     *             @OA\Property(property="data", type="object",
+     *                 @OA\Property(property="id", type="string", example="uuid-string"),
+     *                 @OA\Property(property="teacher_id", type="string", example="uuid-teacher"),
+     *                 @OA\Property(property="category_id", type="string", example="uuid-category"),
+     *                 @OA\Property(property="word", type="string", example="Elephant Updated"),
+     *                 @OA\Property(property="translation", type="string", example="Gajah Besar"),
+     *                 @OA\Property(property="spelling", type="string", example="ˈeləfənt"),
+     *                 @OA\Property(property="explanation", type="string", example="Updated explanation"),
+     *                 @OA\Property(property="audio_file_path", type="string", example="audio/elephant-new.mp3"),
+     *                 @OA\Property(property="is_public", type="boolean", example=0),
+     *                 @OA\Property(property="created_at", type="string", example="2025-08-01T10:00:00Z"),
+     *                 @OA\Property(property="updated_at", type="string", example="2025-08-01T10:00:00Z")
+     *             )
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Vocabulary not found"),
+     *     @OA\Response(response=422, description="Validation failed"),
+     *     @OA\Response(response=500, description="Server error")
+     * )
+     */
+    public function update(Request $request, $id)
+    {
+        $vocabulary = Vocabulary::findOrFail($id);
+        if (!$vocabulary) {
+            return response()->json(['error' => 'Vocabulary not found'], 404);
+        }
+
+        DB::beginTransaction();
+        try{
+            $validator = ValidationHelper::vocabulary($request->all());
+            if ($validator->fails()) {
+                return response()->json(['errors' => $validator->errors()], 422);
+            }
+
+            $existingVocabulary = Vocabulary::where('word', $request->word)->where('id', '!=', $id)->first();
+            if ($existingVocabulary) {
+                return response()->json(['error' => 'Vocabulary word already exists'], 422);
+            }
+
+            $data = $validator->validated();
+
+            $vocabulary->update([
+                'teacher_id' => auth()->user()->id,
+                'category_id' => $data['category_id'],
+                'word' => $data['word'],
+                'translation' => $data['translation'],
+                'spelling' => $data['spelling'],
+                'explanation' => $data['explanation'],
+                'audio_file_path' => isset($data['audio_file_path']) ? $data['audio_file_path'] : $vocabulary->audio_file_path,
+                'is_public' => $data['is_public'],
+            ]);
+
+            DB::commit();
+            return response()->json(['message' => 'Vocabulary updated successfully', 'data' => $vocabulary], 200);
+        } catch (\Exception $e) {
+            return response()->json(['message' => 'Server error' ,'error' => $e->getMessage()], 500);
+        }
+    }
+
+    /**
+     * @OA\Delete(
+     *     path="/api/vocab/delete/{id}",
+     *     tags={"Vocabulary"},
+     *     summary="Delete a vocabulary entry",
+     *     description="Deletes a vocabulary entry by its UUID.",
+     *     security={{"sanctum":{}}},
+     *     @OA\Parameter(
+     *         name="id",
+     *         in="path",
+     *         required=true,
+     *         description="UUID of the vocabulary",
+     *         @OA\Schema(type="string", example="uuid-string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="X-XSRF-TOKEN",
+     *         in="header",
+     *         required=false,
+     *         description="CSRF token for session-based auth (Sanctum)",
+     *         @OA\Schema(type="string")
+     *     ),
+     *     @OA\Parameter(
+     *         name="Referer",
+     *         in="header",
+     *         required=false,
+     *         description="Referring URL Frontend for CSRF protection",
+     *         @OA\Schema(type="string", example="http://localhost:3000")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Vocabulary deleted successfully",
+     *         @OA\JsonContent(
+     *             @OA\Property(property="message", type="string", example="Vocabulary deleted successfully")
+     *         )
+     *     ),
+     *     @OA\Response(response=404, description="Vocabulary not found")
+     * )
+     */
+    public function destroy($id)
+    {
+        $vocabulary = Vocabulary::findOrFail($id);
+        if (!$vocabulary) {
+            return response()->json(['error' => 'Vocabulary not found'], 404);
+        }
+
+        $vocabulary->delete();
+        return response()->json(['message' => 'Vocabulary deleted successfully'], 200);
+    }
+}

--- a/app/Http/Middleware/CheckRole.php
+++ b/app/Http/Middleware/CheckRole.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class CheckRole
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next, ...$roles)
+    {
+        $user = $request->user();
+
+        if (!$user || !in_array($user->role, $roles)) {
+            return response()->json(['message' => 'Access Forbidden'], 403);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Models/Vocabulary.php
+++ b/app/Models/Vocabulary.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class Vocabulary extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'teacher_id',
+        'category_id',
+        'word',
+        'translation',
+        'spelling',
+        'explanation',
+        'audio_file_path',
+        'is_public',
+    ];
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected static function booted()
+    {
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function category()
+    {
+        return $this->belongsTo(VocabularyCategory::class, 'category_id');
+    }
+
+    public function teacher()
+    {
+        return $this->belongsTo(User::class, 'teacher_id');
+    }
+}

--- a/app/Models/VocabularyCategory.php
+++ b/app/Models/VocabularyCategory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class VocabularyCategory extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'color_code',
+    ];
+
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected static function booted()
+    {
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function vocabularies()
+    {
+        return $this->hasMany(Vocabulary::class, 'category_id');
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -5,11 +5,16 @@ use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Session\TokenMismatchException;
 use Symfony\Component\HttpKernel\Exception\HttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(web: __DIR__ . '/../routes/web.php', api: __DIR__ . '/../routes/api.php', commands: __DIR__ . '/../routes/console.php', health: '/up')
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->statefulApi();
+        $middleware->alias([
+            'role' => \App\Http\Middleware\CheckRole::class,
+        ]);
+
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->render(function (TokenMismatchException $e, $request) {
@@ -32,6 +37,18 @@ return Application::configure(basePath: dirname(__DIR__))
                         'error' => 'HttpException-TokenMismatch',
                     ],
                     419,
+                );
+            }
+        });
+
+        $exceptions->render(function (NotFoundHttpException $e, $request) {
+            if ($request->expectsJson()) {
+                return response()->json(
+                    [
+                        'message' => 'Not Found',
+                        'error' => 'NotFoundHttpException',
+                    ],
+                    404,
                 );
             }
         });

--- a/database/migrations/2025_07_15_034941_create_vocabulary_categories_table.php
+++ b/database/migrations/2025_07_15_034941_create_vocabulary_categories_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vocabulary_categories', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('color_code')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vocabulary_categories');
+    }
+};

--- a/database/migrations/2025_07_15_035114_create_vocabularies_table.php
+++ b/database/migrations/2025_07_15_035114_create_vocabularies_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('vocabularies', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('teacher_id');
+            $table->uuid('category_id');
+            $table->string('word');
+            $table->string('translation');
+            $table->string('spelling')->nullable();
+            $table->text('explanation')->nullable();
+            $table->string('audio_file_path')->nullable();
+            $table->boolean('is_public')->default(false);
+            $table->timestamps();
+
+            $table->foreign('teacher_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('category_id')->references('id')->on('vocabulary_categories')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('vocabularies');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -3,6 +3,8 @@
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\VocabularyCategoryController;
+use App\Http\Controllers\VocabularyController;
 
 /**
  * @OA\Info(
@@ -44,4 +46,20 @@ Route::prefix('auth')->group(function () {
         Route::post('/logout', [AuthController::class, 'logout']);
         Route::get('/me', [AuthController::class, 'me']);
     });
+});
+
+Route::middleware(['auth:sanctum', 'role:admin,teacher'])->prefix('vocab')->group(function () {
+    Route::prefix('categories')->group(function () {
+        Route::get('/', [VocabularyCategoryController::class, 'index']);
+        Route::get('/{id}', [VocabularyCategoryController::class, 'show']);
+        Route::post('/create', [VocabularyCategoryController::class, 'store']);
+        Route::patch('/update/{id}', [VocabularyCategoryController::class, 'update']);
+        Route::delete('/delete/{id}', [VocabularyCategoryController::class, 'destroy']);
+    });
+
+    Route::get('/vocabularies', [VocabularyController::class, 'index']);
+    Route::get('/{id}', [VocabularyController::class, 'show']);
+    Route::post('/create', [VocabularyController::class, 'store']);
+    Route::patch('/update/{id}', [VocabularyController::class, 'update']);
+    Route::delete('/delete/{id}', [VocabularyController::class, 'destroy']);
 });

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -377,6 +377,1046 @@
                     }
                 }
             }
+        },
+        "/api/vocab/categories": {
+            "get": {
+                "tags": [
+                    "Vocabulary Categories"
+                ],
+                "summary": "Get all vocabulary categories",
+                "description": "Returns a list of all vocabulary categories.",
+                "operationId": "aa81c1060a88e116e57bc39836e1455e",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of vocabulary categories",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "example": "uuid-string"
+                                            },
+                                            "name": {
+                                                "type": "string",
+                                                "example": "nouns"
+                                            },
+                                            "color_code": {
+                                                "type": "string",
+                                                "example": "#FF0000"
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "example": "2025-07-15T07:19:54.000000Z"
+                                            },
+                                            "updated_at": {
+                                                "type": "string",
+                                                "example": "2025-07-15T07:19:54.000000Z"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/categories/create": {
+            "post": {
+                "tags": [
+                    "Vocabulary Categories"
+                ],
+                "summary": "Create a new vocabulary category",
+                "description": "Adds a new vocabulary category. Requires authentication.",
+                "operationId": "7b4a1e4b73dd2bbff472bd310da04905",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "nouns"
+                                    },
+                                    "color_code": {
+                                        "type": "string",
+                                        "example": "#FF0000"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Category created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Category created successfully"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "example": "uuid-string"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "nouns"
+                                                },
+                                                "color_code": {
+                                                    "type": "string",
+                                                    "example": "#FF0000"
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "example": "2025-07-15T07:19:54.000000Z"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "example": "2025-07-15T07:19:54.000000Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/categories/{id}": {
+            "get": {
+                "tags": [
+                    "Vocabulary Categories"
+                ],
+                "summary": "Get a specific vocabulary category",
+                "description": "Retrieve details of a specific category by its ID.",
+                "operationId": "3aa412353611facc4650612c497e7276",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the category",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Category retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "example": "uuid-string"
+                                        },
+                                        "name": {
+                                            "type": "string",
+                                            "example": "nouns"
+                                        },
+                                        "color_code": {
+                                            "type": "string",
+                                            "example": "#FF0000"
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "example": "2025-07-15T07:19:54.000000Z"
+                                        },
+                                        "updated_at": {
+                                            "type": "string",
+                                            "example": "2025-07-15T07:19:54.000000Z"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Category not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/categories/update/{id}": {
+            "patch": {
+                "tags": [
+                    "Vocabulary Categories"
+                ],
+                "summary": "Update an existing vocabulary category",
+                "description": "Update a vocabulary category's name or description.",
+                "operationId": "12c346f2bea07ebffb85618db290036d",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the category",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "name"
+                                ],
+                                "properties": {
+                                    "name": {
+                                        "type": "string",
+                                        "example": "verb"
+                                    },
+                                    "color_code": {
+                                        "type": "string",
+                                        "example": "#FFA000"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Category created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Category created successfully"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "example": "uuid-string"
+                                                },
+                                                "name": {
+                                                    "type": "string",
+                                                    "example": "verb"
+                                                },
+                                                "color_code": {
+                                                    "type": "string",
+                                                    "example": "#FFA000"
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "example": "2025-07-15T07:19:54.000000Z"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "example": "2025-07-15T07:19:54.000000Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Category not found"
+                    },
+                    "422": {
+                        "description": "Validation failed"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocabulary-categories/{id}": {
+            "delete": {
+                "tags": [
+                    "Vocabulary Categories"
+                ],
+                "summary": "Delete a vocabulary category",
+                "description": "Delete a category by its UUID.",
+                "operationId": "c61b0fa02aa3bc51be0e1685123053b3",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the category",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Category deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Category deleted successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Category not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/vocabularies": {
+            "get": {
+                "tags": [
+                    "Vocabulary"
+                ],
+                "summary": "Get all vocabularies",
+                "description": "Returns a list of all vocabulary entries.",
+                "operationId": "8deda9b34a4e017b542cd087eadd78c1",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of vocabulary entries",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "array",
+                                    "items": {
+                                        "properties": {
+                                            "id": {
+                                                "type": "string",
+                                                "example": "uuid-string"
+                                            },
+                                            "teacher_id": {
+                                                "type": "string",
+                                                "example": "uuid-teacher"
+                                            },
+                                            "category_id": {
+                                                "type": "string",
+                                                "example": "uuid-category"
+                                            },
+                                            "word": {
+                                                "type": "string",
+                                                "example": "Elephant"
+                                            },
+                                            "translation": {
+                                                "type": "string",
+                                                "example": "Gajah"
+                                            },
+                                            "spelling": {
+                                                "type": "string",
+                                                "example": "ˈeləfənt"
+                                            },
+                                            "explanation": {
+                                                "type": "string",
+                                                "example": "A large mammal with trunk."
+                                            },
+                                            "audio_file_path": {
+                                                "type": "string",
+                                                "example": "audio/elephant.mp3"
+                                            },
+                                            "is_public": {
+                                                "type": "boolean",
+                                                "example": 1
+                                            },
+                                            "created_at": {
+                                                "type": "string",
+                                                "example": "2025-08-01T10:00:00Z"
+                                            },
+                                            "updated_at": {
+                                                "type": "string",
+                                                "example": "2025-08-01T10:00:00Z"
+                                            }
+                                        },
+                                        "type": "object"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/create": {
+            "post": {
+                "tags": [
+                    "Vocabulary"
+                ],
+                "summary": "Create a new vocabulary entry",
+                "description": "Adds a new vocabulary entry to the system.",
+                "operationId": "2f4905fe290f9629fe6d93ae00a0addd",
+                "parameters": [
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "required": [
+                                    "category_id",
+                                    "word",
+                                    "translation",
+                                    "is_public"
+                                ],
+                                "properties": {
+                                    "category_id": {
+                                        "type": "string",
+                                        "example": "uuid-category"
+                                    },
+                                    "word": {
+                                        "type": "string",
+                                        "example": "Elephant"
+                                    },
+                                    "translation": {
+                                        "type": "string",
+                                        "example": "Gajah"
+                                    },
+                                    "spelling": {
+                                        "type": "string",
+                                        "example": "ˈeləfənt"
+                                    },
+                                    "explanation": {
+                                        "type": "string",
+                                        "example": "A large mammal with trunk."
+                                    },
+                                    "audio_file_path": {
+                                        "type": "string",
+                                        "example": "audio/elephant.mp3"
+                                    },
+                                    "is_public": {
+                                        "type": "boolean",
+                                        "example": 1
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Vocabulary created successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vocabulary created successfully"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "example": "uuid-string"
+                                                },
+                                                "teacher_id": {
+                                                    "type": "string",
+                                                    "example": "uuid-teacher"
+                                                },
+                                                "category_id": {
+                                                    "type": "string",
+                                                    "example": "uuid-category"
+                                                },
+                                                "word": {
+                                                    "type": "string",
+                                                    "example": "Elephant"
+                                                },
+                                                "translation": {
+                                                    "type": "string",
+                                                    "example": "Gajah"
+                                                },
+                                                "spelling": {
+                                                    "type": "string",
+                                                    "example": "ˈeləfənt"
+                                                },
+                                                "explanation": {
+                                                    "type": "string",
+                                                    "example": "A large mammal with trunk."
+                                                },
+                                                "audio_file_path": {
+                                                    "type": "string",
+                                                    "example": "audio/elephant.mp3"
+                                                },
+                                                "is_public": {
+                                                    "type": "boolean",
+                                                    "example": 1
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "example": "2025-08-01T10:00:00Z"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "example": "2025-08-01T10:00:00Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "description": "Validation failed"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/{id}": {
+            "get": {
+                "tags": [
+                    "Vocabulary"
+                ],
+                "summary": "Get a specific vocabulary entry",
+                "description": "Retrieve details of a vocabulary entry by its ID.",
+                "operationId": "6d139319c3bfab78f8915a27fb55eba4",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the vocabulary",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Vocabulary retrieved successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "id": {
+                                            "type": "string",
+                                            "example": "uuid-string"
+                                        },
+                                        "teacher_id": {
+                                            "type": "string",
+                                            "example": "uuid-teacher"
+                                        },
+                                        "category_id": {
+                                            "type": "string",
+                                            "example": "uuid-category"
+                                        },
+                                        "word": {
+                                            "type": "string",
+                                            "example": "Elephant"
+                                        },
+                                        "translation": {
+                                            "type": "string",
+                                            "example": "Gajah"
+                                        },
+                                        "spelling": {
+                                            "type": "string",
+                                            "example": "ˈeləfənt"
+                                        },
+                                        "explanation": {
+                                            "type": "string",
+                                            "example": "A large mammal with trunk."
+                                        },
+                                        "audio_file_path": {
+                                            "type": "string",
+                                            "example": "audio/elephant.mp3"
+                                        },
+                                        "is_public": {
+                                            "type": "boolean",
+                                            "example": 1
+                                        },
+                                        "created_at": {
+                                            "type": "string",
+                                            "example": "2025-08-01T10:00:00Z"
+                                        },
+                                        "updated_at": {
+                                            "type": "string",
+                                            "example": "2025-08-01T10:00:00Z"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Vocabulary not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/update/{id}": {
+            "patch": {
+                "tags": [
+                    "Vocabulary"
+                ],
+                "summary": "Update a vocabulary entry",
+                "description": "Updates an existing vocabulary entry.\n     *     **Note:** If using form-data or POST, include params `_method=PATCH`.",
+                "operationId": "8f39630d626e23bdb7b32f625e478c92",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the vocabulary",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "category_id": {
+                                        "type": "string",
+                                        "example": "uuid-category"
+                                    },
+                                    "word": {
+                                        "type": "string",
+                                        "example": "Elephant Updated"
+                                    },
+                                    "translation": {
+                                        "type": "string",
+                                        "example": "Gajah Besar"
+                                    },
+                                    "spelling": {
+                                        "type": "string",
+                                        "example": "ˈeləfənt"
+                                    },
+                                    "explanation": {
+                                        "type": "string",
+                                        "example": "Updated explanation"
+                                    },
+                                    "audio_file_path": {
+                                        "type": "string",
+                                        "example": "audio/elephant-new.mp3"
+                                    },
+                                    "is_public": {
+                                        "type": "boolean",
+                                        "example": 0
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Vocabulary updated successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vocabulary updated successfully"
+                                        },
+                                        "data": {
+                                            "properties": {
+                                                "id": {
+                                                    "type": "string",
+                                                    "example": "uuid-string"
+                                                },
+                                                "teacher_id": {
+                                                    "type": "string",
+                                                    "example": "uuid-teacher"
+                                                },
+                                                "category_id": {
+                                                    "type": "string",
+                                                    "example": "uuid-category"
+                                                },
+                                                "word": {
+                                                    "type": "string",
+                                                    "example": "Elephant Updated"
+                                                },
+                                                "translation": {
+                                                    "type": "string",
+                                                    "example": "Gajah Besar"
+                                                },
+                                                "spelling": {
+                                                    "type": "string",
+                                                    "example": "ˈeləfənt"
+                                                },
+                                                "explanation": {
+                                                    "type": "string",
+                                                    "example": "Updated explanation"
+                                                },
+                                                "audio_file_path": {
+                                                    "type": "string",
+                                                    "example": "audio/elephant-new.mp3"
+                                                },
+                                                "is_public": {
+                                                    "type": "boolean",
+                                                    "example": 0
+                                                },
+                                                "created_at": {
+                                                    "type": "string",
+                                                    "example": "2025-08-01T10:00:00Z"
+                                                },
+                                                "updated_at": {
+                                                    "type": "string",
+                                                    "example": "2025-08-01T10:00:00Z"
+                                                }
+                                            },
+                                            "type": "object"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Vocabulary not found"
+                    },
+                    "422": {
+                        "description": "Validation failed"
+                    },
+                    "500": {
+                        "description": "Server error"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
+        },
+        "/api/vocab/delete/{id}": {
+            "delete": {
+                "tags": [
+                    "Vocabulary"
+                ],
+                "summary": "Delete a vocabulary entry",
+                "description": "Deletes a vocabulary entry by its UUID.",
+                "operationId": "8e62d2bc3c170c1d880b56cd72a31ca8",
+                "parameters": [
+                    {
+                        "name": "id",
+                        "in": "path",
+                        "description": "UUID of the vocabulary",
+                        "required": true,
+                        "schema": {
+                            "type": "string",
+                            "example": "uuid-string"
+                        }
+                    },
+                    {
+                        "name": "X-XSRF-TOKEN",
+                        "in": "header",
+                        "description": "CSRF token for session-based auth (Sanctum)",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "name": "Referer",
+                        "in": "header",
+                        "description": "Referring URL Frontend for CSRF protection",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "example": "http://localhost:3000"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Vocabulary deleted successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "message": {
+                                            "type": "string",
+                                            "example": "Vocabulary deleted successfully"
+                                        }
+                                    },
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "Vocabulary not found"
+                    }
+                },
+                "security": [
+                    {
+                        "sanctum": []
+                    }
+                ]
+            }
         }
     },
     "tags": [
@@ -387,6 +1427,14 @@
         {
             "name": "Test",
             "description": "Test"
+        },
+        {
+            "name": "Vocabulary Categories",
+            "description": "Vocabulary Categories"
+        },
+        {
+            "name": "Vocabulary",
+            "description": "Vocabulary"
         }
     ]
 }


### PR DESCRIPTION
### What’s added
- `VocabularyCategoryController.php` with CRUD endpoints
- `VocabularyController.php` with CRUD endpoints
- `Vocabulary.php` and `VocabularyCategory.php` models with UUID primary keys
- Migrations:
  - `2025_07_15_034941_create_vocabulary_categories_table.php`
  - `2025_07_15_035114_create_vocabularies_table.php`
- Validation rules in `ValidationHelper.php` for vocabulary & category
- Role-based access via middleware (`admin`, `teacher`)
- Swagger annotations for all vocabulary & category endpoints

### Why
- Provide API endpoints for managing vocabulary & categories
- Ensure data consistency with validation rules
- Role-based security to restrict access only to teachers and admins
- Properly documented API for frontend integration

### Changes
#### Modified
- `app/Helpers/ValidationHelper.php` → added validation rules for vocabulary & category
- `bootstrap/app.php` → register middleware & exception handling
- `routes/api.php` → added vocabulary & category endpoints
- `storage/api-docs/api-docs.json` → updated Swagger docs

#### Added
- `app/Http/Controllers/VocabularyCategoryController.php`
- `app/Http/Controllers/VocabularyController.php`
- `app/Http/Middleware/` (role-based access middleware)
- `app/Models/Vocabulary.php`
- `app/Models/VocabularyCategory.php`
- `database/migrations/2025_07_15_034941_create_vocabulary_categories_table.php`
- `database/migrations/2025_07_15_035114_create_vocabularies_table.php`

### Notes
- Requires authentication via Sanctum with `X-XSRF-TOKEN` header (session-based auth)
- Only `admin` and `teacher` roles can access these endpoints
- Tested via Postman with session cookies
- Swagger UI now shows all vocabulary & category endpoints correctly