### PR TITLE
feat(assessment): add models, migrations, and category seeder for assessment modules

### DIFF
--- a/app/Models/Assignment.php
+++ b/app/Models/Assignment.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $class_id
+ * @property string $test_id
+ * @property string $title
+ * @property string $description
+ * @property string $due_date
+ * @property string $close_date
+ * @property string $is_published
+ * @property string $auto_grade
+ * @property string $allow_retake
+ * @property string $max_attempts
+ */
+class Assignment extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'assignments';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'class_id',
+        'test_id',
+        'title',
+        'description',
+        'due_date',
+        'close_date',
+        'is_published',
+        'auto_grade',
+        'allow_retake',
+        'max_attempts',
+    ];
+
+    protected $casts = [
+        'is_published' => 'boolean',
+        'auto_grade' => 'boolean',
+        'allow_retake' => 'boolean',
+    ];
+
+    public function class()
+    {
+        return $this->belongsTo(Classes::class, 'class_id');
+    }
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class, 'test_id');
+    }
+
+    public function classAnalytics()
+    {
+        return $this->hasMany(ClassAnalytic::class, 'assignment_id');
+    }
+
+    public function studentAssignments()
+    {
+        return $this->hasMany(StudentAssignment::class, 'assignment_id');
+    }
+
+    public function classLeaderboards()
+    {
+        return $this->hasMany(ClassLeaderboard::class, 'assignment_id');
+    }
+}

--- a/app/Models/AudioRecording.php
+++ b/app/Models/AudioRecording.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $question_id
+ * @property string $user_id
+ * @property string $audio_file_path
+ * @property string $audio_format
+ * @property int $duration_seconds
+ * @property string $transcript
+ * @property array $audio_analysis
+ * @property string $recorded_at
+ */
+class AudioRecording extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'audio_recordings';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'question_id',
+        'user_id',
+        'audio_file_path',
+        'audio_format',
+        'duration_seconds',
+        'transcript',
+        'audio_analysis',
+        'recorded_at',
+    ];
+
+    protected $casts = [
+        'duration_seconds' => 'integer',
+        'audio_analysis' => 'array',
+        'recorded_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function question()
+    {
+        return $this->belongsTo(TestQuestion::class, 'question_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/ClassAnalytic.php
+++ b/app/Models/ClassAnalytic.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $class_id
+ * @property string $assignment_id
+ * @property float $average_score
+ * @property array $skill_breakdown
+ * @property array $performance_insights
+ * @property array $common_mistakes
+ * @property string $calculated_at
+ */
+class ClassAnalytic extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'class_analytics';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'class_id',
+        'assignment_id',
+        'average_score',
+        'skill_breakdown',
+        'performance_insights',
+        'common_mistakes',
+        'calculated_at',
+    ];
+
+    protected $casts = [
+        'average_score' => 'decimal:2',
+        'skill_breakdown' => 'array',
+        'performance_insights' => 'array',
+        'common_mistakes' => 'array',
+        'calculated_at' => 'datetime',
+    ];
+
+    public function class()
+    {
+        return $this->belongsTo(Classes::class, 'class_id');
+    }
+
+    public function assignment()
+    {
+        return $this->belongsTo(Assignment::class, 'assignment_id');
+    }
+}

--- a/app/Models/ClassEnrollment.php
+++ b/app/Models/ClassEnrollment.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -15,7 +15,7 @@ use Illuminate\Support\Str;
  */
 class ClassEnrollment extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
 
     protected $table = 'class_enrollments';
     public $incrementing = false;
@@ -27,16 +27,6 @@ class ClassEnrollment extends Model
         'status',
         'enrolled_at',
     ];
-
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
 
     public function class()
     {

--- a/app/Models/ClassInvitation.php
+++ b/app/Models/ClassInvitation.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -18,7 +18,7 @@ use Illuminate\Support\Str;
  */
 class ClassInvitation extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
 
     protected $table = 'class_invitations';
     public $incrementing = false;
@@ -34,17 +34,6 @@ class ClassInvitation extends Model
         'expires_at',
     ];
 
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
-
-    /** Relationships */
     public function class()
     {
         return $this->belongsTo(Classes::class, 'class_id');

--- a/app/Models/ClassLeaderboard.php
+++ b/app/Models/ClassLeaderboard.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $class_id
+ * @property string $assignment_id
+ * @property string $student_id
+ * @property float $score
+ * @property int $rank_position
+ * @property string $submission_status
+ * @property string $submission_date
+ */
+class ClassLeaderboard extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'class_leaderboards';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'class_id',
+        'assignment_id',
+        'student_id',
+        'score',
+        'rank_position',
+        'submission_status',
+        'submission_date',
+    ];
+
+    protected $casts = [
+        'score' => 'decimal:2',
+        'submission_date' => 'datetime',
+    ];
+
+    public function class()
+    {
+        return $this->belongsTo(Classes::class, 'class_id');
+    }
+
+    public function assignment()
+    {
+        return $this->belongsTo(Assignment::class, 'assignment_id');
+    }
+
+    public function student()
+    {
+        return $this->belongsTo(User::class, 'student_id');
+    }
+}

--- a/app/Models/ClassVocabulary.php
+++ b/app/Models/ClassVocabulary.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -14,25 +14,17 @@ use Illuminate\Support\Str;
  */
 class ClassVocabulary extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $table = 'class_vocabulary';
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     protected $fillable = [
         'class_id',
         'vocabulary_id',
         'assigned_at',
     ];
-
-    public $incrementing = false;
-    protected $keyType = 'string';
-
-    protected static function booted()
-    {
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
 
     public function class()
     {

--- a/app/Models/Classes.php
+++ b/app/Models/Classes.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -17,7 +17,7 @@ use Illuminate\Support\Str;
  */
 class Classes extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
 
     protected $table = 'classes';
     public $incrementing = false;
@@ -32,15 +32,9 @@ class Classes extends Model
         'is_active'
     ];
 
-    protected static function boot()
-    {
-        parent::boot();
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
+    protected $casts = [
+        'is_active' => 'boolean'
+    ];
 
     public function teacher()
     {
@@ -60,5 +54,10 @@ class Classes extends Model
     public function vocabularies()
     {
         return $this->belongsToMany(Vocabulary::class, 'class_vocabularies', 'class_id', 'vocabulary_id')->withPivot('assigned_at')->withTimestamps();
+    }
+
+    public function assignments()
+    {
+        return $this->hasMany(Assignment::class, 'class_id');
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $type
+ * @property string $title
+ * @property string $message
+ * @property array $data
+ * @property boolean $is_read
+ * @property string $read_at
+ */
+class Notification extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'notifications';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'type',
+        'title',
+        'message',
+        'data',
+        'is_read',
+        'read_at',
+    ];
+
+    protected $casts = [
+        'data' => 'array',
+        'is_read' => 'boolean',
+        'read_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/PasswordResetToken.php
+++ b/app/Models/PasswordResetToken.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property string $email
+ * @property string $token
+ * @property string $created_at
+ */
+class PasswordResetToken extends Model
+{
+    use HasFactory;
+
+    protected $table = 'password_reset_tokens';
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $primaryKey = 'email';
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'email',
+        'token',
+        'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+}

--- a/app/Models/PublicTest.php
+++ b/app/Models/PublicTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $admin_id
+ * @property string $name
+ * @property string $type
+ * @property string $difficulty
+ * @property string $description
+ * @property array $question_types
+ * @property boolean $is_published
+ * @property boolean $is_featured
+ * @property int $total_attempts
+ * @property float $average_rating
+ * @property string $published_at
+ */
+class PublicTest extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'public_tests';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'admin_id',
+        'name',
+        'type',
+        'difficulty',
+        'description',
+        'question_types',
+        'is_published',
+        'is_featured',
+        'total_attempts',
+        'average_rating',
+        'published_at',
+    ];
+
+    protected $casts = [
+        'question_types' => 'array',
+        'is_published' => 'boolean',
+        'is_featured' => 'boolean',
+        'average_rating' => 'decimal:2',
+        'published_at' => 'datetime',
+    ];
+
+    public function admin()
+    {
+        return $this->belongsTo(User::class, 'admin_id');
+    }
+
+    public function attempts()
+    {
+        return $this->hasMany(PublicTestAttempt::class, 'public_test_id');
+    }
+}

--- a/app/Models/PublicTestAttempt.php
+++ b/app/Models/PublicTestAttempt.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $public_test_id
+ * @property float $score
+ * @property int $time_spent_seconds
+ * @property array $performance_data
+ * @property float $rating
+ * @property string $feedback
+ * @property string $completed_at
+ */
+class PublicTestAttempt extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'public_test_attempts';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'public_test_id',
+        'score',
+        'time_spent_seconds',
+        'performance_data',
+        'rating',
+        'feedback',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'score' => 'decimal:2',
+        'performance_data' => 'array',
+        'rating' => 'decimal:2',
+        'completed_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function publicTest()
+    {
+        return $this->belongsTo(PublicTest::class, 'public_test_id');
+    }
+}

--- a/app/Models/QuestionInstruction.php
+++ b/app/Models/QuestionInstruction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ *
+ * @property string $id
+ * @property string $test_id
+ * @property string $question_type_id
+ * @property string $instruction_text
+ */
+class QuestionInstruction extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'question_instructions';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'test_id',
+        'question_type_id',
+        'instruction_text',
+    ];
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class);
+    }
+
+    public function questionType()
+    {
+        return $this->belongsTo(QuestionType::class);
+    }
+
+    public function questions()
+    {
+        return $this->hasMany(TestQuestion::class);
+    }
+}

--- a/app/Models/QuestionOption.php
+++ b/app/Models/QuestionOption.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $question_id
+ * @property string $option_key
+ * @property string $option_text
+ * @property bool $is_correct
+ * @property int $display_order
+ */
+class QuestionOption extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'question_options';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'question_id',
+        'option_key',
+        'option_text',
+        'is_correct',
+        'display_order',
+    ];
+
+    protected $casts = [
+        'is_correct' => 'boolean',
+    ];
+
+    public function question()
+    {
+        return $this->belongsTo(TestQuestion::class, 'question_id');
+    }
+}

--- a/app/Models/QuestionResponse.php
+++ b/app/Models/QuestionResponse.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $question_id
+ * @property string $user_id
+ * @property array $student_answer
+ * @property bool $is_correct
+ * @property float $points_earned
+ * @property string $answered_at
+ */
+class QuestionResponse extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'question_responses';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'question_id',
+        'user_id',
+        'student_answer',
+        'is_correct',
+        'points_earned',
+        'answered_at',
+    ];
+
+    protected $casts = [
+        'student_answer' => 'array',
+        'is_correct' => 'boolean',
+        'points_earned' => 'decimal:2',
+        'answered_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function question()
+    {
+        return $this->belongsTo(TestQuestion::class, 'question_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/QuestionType.php
+++ b/app/Models/QuestionType.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property string $category
+ * @property array $template_structure
+ * @property array $scoring_rules
+ * @property boolean $is_active
+ */
+class QuestionType extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'question_types';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'name',
+        'category',
+        'template_structure',
+        'scoring_rules',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'template_structure' => 'array',
+        'scoring_rules' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function questions()
+    {
+        return $this->hasMany(TestQuestion::class, 'question_type_id');
+    }
+
+    public function questionInstructions()
+    {
+        return $this->hasMany(QuestionInstruction::class);
+    }
+}

--- a/app/Models/QuestionTypePerformance.php
+++ b/app/Models/QuestionTypePerformance.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $question_type_name
+ * @property string $skill_category
+ * @property int $total_attempts
+ * @property int $correct_answers
+ * @property float $accuracy_percentage
+ * @property array $performance_history
+ * @property string $last_attempt
+ */
+class QuestionTypePerformance extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'question_type_performance';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'question_type_name',
+        'skill_category',
+        'total_attempts',
+        'correct_answers',
+        'accuracy_percentage',
+        'performance_history',
+        'last_attempt',
+    ];
+
+    protected $casts = [
+        'accuracy_percentage' => 'decimal:2',
+        'performance_history' => 'array',
+        'last_attempt' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/SocialAccount.php
+++ b/app/Models/SocialAccount.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $provider
+ * @property string $provider_id
+ * @property string $provider_token
+ */
+class SocialAccount extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'social_accounts';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'provider',
+        'provider_id',
+        'provider_token',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/SpeakingAssessment.php
+++ b/app/Models/SpeakingAssessment.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $user_id
+ * @property float $fluency_coherence_score
+ * @property float $lexical_resource_score
+ * @property float $grammatical_range_accuracy_score
+ * @property float $pronunciation_score
+ * @property float $overall_score
+ * @property array $detailed_feedback
+ * @property array $grammar_analysis
+ * @property array $improvement_suggestions
+ * @property string $assessed_at
+ */
+class SpeakingAssessment extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'speaking_assessments';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'user_id',
+        'fluency_coherence_score',
+        'lexical_resource_score',
+        'grammatical_range_accuracy_score',
+        'pronunciation_score',
+        'overall_score',
+        'detailed_feedback',
+        'grammar_analysis',
+        'improvement_suggestions',
+        'assessed_at',
+    ];
+
+    protected $casts = [
+        'fluency_coherence_score' => 'decimal:2',
+        'lexical_resource_score' => 'decimal:2',
+        'grammatical_range_accuracy_score' => 'decimal:2',
+        'pronunciation_score' => 'decimal:2',
+        'overall_score' => 'decimal:2',
+        'detailed_feedback' => 'array',
+        'grammar_analysis' => 'array',
+        'assessed_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/StudentAssignment.php
+++ b/app/Models/StudentAssignment.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $assignment_id
+ * @property string $student_id
+ * @property string $status
+ * @property float $score
+ * @property int $attempt_number
+ * @property array $submission_data
+ * @property string $started_at
+ * @property string $completed_at
+ * @property string $submitted_at
+ */
+class StudentAssignment extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'student_assignments';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'assignment_id',
+        'student_id',
+        'status',
+        'score',
+        'attempt_number',
+        'submission_data',
+        'started_at',
+        'completed_at',
+        'submitted_at',
+    ];
+
+    protected $casts = [
+        'score' => 'decimal:2',
+        'submission_data' => 'array',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'submitted_at' => 'datetime',
+    ];
+
+    public function assignment()
+    {
+        return $this->belongsTo(Assignment::class, 'assignment_id');
+    }
+
+    public function student()
+    {
+        return $this->belongsTo(User::class, 'student_id');
+    }
+}

--- a/app/Models/StudentProgress.php
+++ b/app/Models/StudentProgress.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $skill_type
+ * @property int $tasks_completed
+ * @property int $total_time_spent_seconds
+ * @property float $average_score
+ * @property array $monthly_performance
+ * @property array $weakest_question_types
+ * @property array $improvement_trends
+ * @property string $last_updated
+ */
+class StudentProgress extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'student_progress';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'skill_type',
+        'tasks_completed',
+        'total_time_spent_seconds',
+        'average_score',
+        'monthly_performance',
+        'weakest_question_types',
+        'improvement_trends',
+        'last_updated',
+    ];
+
+    protected $casts = [
+        'average_score' => 'decimal:2',
+        'monthly_performance' => 'array',
+        'weakest_question_types' => 'array',
+        'improvement_trends' => 'array',
+        'last_updated' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/TeacherDashboardStat.php
+++ b/app/Models/TeacherDashboardStat.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $teacher_id
+ * @property int $total_students
+ * @property int $total_classes
+ * @property int $total_tests_created
+ * @property int $total_assignments
+ * @property array $monthly_activity
+ * @property array $class_performance_summary
+ * @property string $last_calculated
+ */
+class TeacherDashboardStat extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'teacher_dashboard_stats';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'teacher_id',
+        'total_students',
+        'total_classes',
+        'total_tests_created',
+        'total_assignments',
+        'monthly_activity',
+        'class_performance_summary',
+        'last_calculated',
+    ];
+
+    protected $casts = [
+        'monthly_activity' => 'array',
+        'class_performance_summary' => 'array',
+        'last_calculated' => 'datetime',
+    ];
+
+    public function teacher()
+    {
+        return $this->belongsTo(User::class, 'teacher_id');
+    }
+}

--- a/app/Models/TeacherPlan.php
+++ b/app/Models/TeacherPlan.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $name
+ * @property float $price
+ * @property int $max_students
+ * @property int $max_classrooms
+ * @property boolean $can_create_tests
+ * @property boolean $priority_support
+ * @property array $features
+ * @property boolean $is_active
+ */
+class TeacherPlan extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'teacher_plans';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'name',
+        'price',
+        'max_students',
+        'max_classrooms',
+        'can_create_tests',
+        'priority_support',
+        'features',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'price' => 'decimal:2',
+        'can_create_tests' => 'boolean',
+        'priority_support' => 'boolean',
+        'features' => 'array',
+        'is_active' => 'boolean',
+    ];
+
+    public function subscriptions()
+    {
+        return $this->hasMany(TeacherSubscription::class, 'teacher_plan_id');
+    }
+}

--- a/app/Models/TeacherSubscription.php
+++ b/app/Models/TeacherSubscription.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $teacher_plan_id
+ * @property string $started_at
+ * @property string $expires_at
+ * @property string $status
+ */
+class TeacherSubscription extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'teacher_subscriptions';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'teacher_plan_id',
+        'started_at',
+        'expires_at',
+        'status',
+    ];
+
+    protected $casts = [
+        'started_at' => 'datetime',
+        'expires_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function plan()
+    {
+        return $this->belongsTo(TeacherPlan::class, 'teacher_plan_id');
+    }
+}

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $creator_id
+ * @property string $name
+ * @property string $type
+ * @property string $difficulty
+ * @property string $description
+ * @property string $time_limit_minutes
+ * @property string $total_questions
+ * @property string $is_published
+ * @property string $is_public
+ * @property string $allow_repetition
+ * @property string $max_repetition_count
+ * @property array $settings
+ */
+class Test extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'tests';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'creator_id',
+        'name',
+        'type',
+        'difficulty',
+        'description',
+        'time_limit_minutes',
+        'total_questions',
+        'is_published',
+        'is_public',
+        'allow_repetition',
+        'max_repetition_count',
+        'settings',
+    ];
+
+    protected $casts = [
+        'settings' => 'array',
+        'is_published' => 'boolean',
+        'is_public' => 'boolean',
+        'allow_repetition' => 'boolean',
+    ];
+
+    protected static function booted()
+    {
+        static::creating(function ($model) {
+            if (!$model->getKey()) {
+                $model->{$model->getKeyName()} = (string) Str::uuid();
+            }
+        });
+    }
+
+    public function creator()
+    {
+        return $this->belongsTo(User::class, 'creator_id');
+    }
+
+    public function assignments()
+    {
+        return $this->hasMany(Assignment::class, 'test_id');
+    }
+
+    public function passages()
+    {
+        return $this->hasMany(TestPassage::class, 'test_id');
+    }
+
+    public function contentFiles()
+    {
+        return $this->hasMany(TestContentFile::class, 'test_id');
+    }
+
+    public function questions()
+    {
+        return $this->hasMany(TestQuestion::class, 'test_id');
+    }
+
+    public function sessions()
+    {
+        return $this->hasMany(TestSession::class, 'test_id');
+    }
+
+    public function questionInstructions()
+    {
+        return $this->hasMany(QuestionInstruction::class);
+    }
+}

--- a/app/Models/TestContentFile.php
+++ b/app/Models/TestContentFile.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $test_id
+ * @property string $filename
+ * @property string $file_path
+ * @property string $file_type
+ * @property string $mime_type
+ * @property string $file_size
+ * @property array $ocr_data
+ */
+class TestContentFile extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'test_content_files';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'test_id',
+        'filename',
+        'file_path',
+        'file_type',
+        'mime_type',
+        'file_size',
+        'ocr_data',
+    ];
+
+    protected $casts = [
+        'ocr_data' => 'array',
+    ];
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class);
+    }
+}

--- a/app/Models/TestPassage.php
+++ b/app/Models/TestPassage.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $test_id
+ * @property string $passage_number
+ * @property string $title
+ * @property string $content
+ * @property string $audio_file_path
+ * @property array $metadata
+ */
+class TestPassage extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'test_passages';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'test_id',
+        'passage_number',
+        'title',
+        'content',
+        'audio_file_path',
+        'metadata',
+    ];
+
+    protected $casts = [
+        'metadata' => 'array',
+    ];
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class);
+    }
+
+    public function questions()
+    {
+        return $this->hasMany(TestQuestion::class, 'passage_id');
+    }
+}

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $test_id
+ * @property string $passage_id
+ * @property string $question_type_id
+ * @property string $question_number
+ * @property string $question_group
+ * @property string $question_text
+ * @property string $question_data
+ * @property string $correct_answers
+ * @property string $points_value
+ * @property string $explanation
+ * @property string $audio_start_time
+ * @property string $audio_end_time
+ */
+class TestQuestion extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'test_questions';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'test_id',
+        'passage_id',
+        'question_type_id',
+        'question_number',
+        'question_group',
+        'question_text',
+        'question_data',
+        'correct_answers',
+        'points_value',
+        'explanation',
+        'audio_start_time',
+        'audio_end_time',
+    ];
+
+    protected $casts = [
+        'question_data' => 'array',
+        'correct_answers' => 'array',
+        'points_value' => 'decimal:2',
+    ];
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class);
+    }
+
+    public function passage()
+    {
+        return $this->belongsTo(TestPassage::class, 'passage_id');
+    }
+
+    public function questionType()
+    {
+        return $this->belongsTo(QuestionType::class);
+    }
+
+    public function options()
+    {
+        return $this->hasMany(QuestionOption::class, 'question_id');
+    }
+
+    public function responses()
+    {
+        return $this->hasMany(QuestionResponse::class, 'question_id');
+    }
+
+    public function audioRecordings()
+    {
+        return $this->hasMany(AudioRecording::class, 'question_id');
+    }
+
+    public function instruction()
+    {
+        return $this->belongsTo(QuestionInstruction::class, 'question_instruction_id');
+    }
+}

--- a/app/Models/TestResult.php
+++ b/app/Models/TestResult.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $user_id
+ * @property string $test_id
+ * @property string $test_type
+ * @property float $total_score
+ * @property float $percentage_score
+ * @property int $questions_correct
+ * @property int $questions_incorrect
+ * @property int $questions_missed
+ * @property array $detailed_breakdown
+ * @property array $performance_analytics
+ * @property string $calculated_at
+ */
+class TestResult extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'test_results';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'user_id',
+        'test_id',
+        'test_type',
+        'total_score',
+        'percentage_score',
+        'questions_correct',
+        'questions_incorrect',
+        'questions_missed',
+        'detailed_breakdown',
+        'performance_analytics',
+        'calculated_at',
+    ];
+
+    protected $casts = [
+        'total_score' => 'decimal:2',
+        'percentage_score' => 'decimal:2',
+        'detailed_breakdown' => 'array',
+        'performance_analytics' => 'array',
+        'calculated_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class, 'test_id');
+    }
+}

--- a/app/Models/TestSession.php
+++ b/app/Models/TestSession.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $test_id
+ * @property string $assignment_id
+ * @property string $attempt_number
+ * @property string $test_type
+ * @property array $session_data
+ * @property string $status
+ * @property string $started_at
+ * @property string $last_activity_at
+ * @property string $completed_at
+ */
+class TestSession extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'test_sessions';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'user_id',
+        'test_id',
+        'assignment_id',
+        'attempt_number',
+        'test_type',
+        'session_data',
+        'status',
+        'started_at',
+        'last_activity_at',
+        'completed_at',
+    ];
+
+    protected $casts = [
+        'session_data' => 'array',
+        'started_at' => 'datetime',
+        'last_activity_at' => 'datetime',
+        'completed_at' => 'datetime',
+    ];
+
+    public function test()
+    {
+        return $this->belongsTo(Test::class);
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function assignment()
+    {
+        return $this->belongsTo(Assignment::class);
+    }
+
+    public function responses()
+    {
+        return $this->hasMany(QuestionResponse::class, 'session_id');
+    }
+
+    public function audioRecordings()
+    {
+        return $this->hasMany(AudioRecording::class, 'session_id');
+    }
+
+    public function writingSubmissions()
+    {
+        return $this->hasMany(WritingSubmission::class, 'session_id');
+    }
+
+    public function testResults()
+    {
+        return $this->hasMany(TestResult::class, 'session_id');
+    }
+
+    public function speakingAssessments()
+    {
+        return $this->hasMany(SpeakingAssessment::class, 'session_id');
+    }
+}

--- a/app/Models/UserVocabularyBookmark.php
+++ b/app/Models/UserVocabularyBookmark.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -14,7 +14,11 @@ use Illuminate\Support\Str;
  */
 class UserVocabularyBookmark extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $table = 'user_vocabulary_bookmarks';
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     protected $fillable = [
         'user_id',
@@ -22,17 +26,9 @@ class UserVocabularyBookmark extends Model
         'is_bookmarked',
     ];
 
-    public $incrementing = false;
-    protected $keyType = 'string';
-
-    protected static function booted()
-    {
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
+    protected $casts = [
+        'is_bookmarked' => 'boolean',
+    ];
 
     public function user()
     {

--- a/app/Models/UserVocabularyProgress.php
+++ b/app/Models/UserVocabularyProgress.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -16,7 +16,11 @@ use Illuminate\Support\Str;
  */
 class UserVocabularyProgress extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $table = 'user_vocabulary_progress';
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     protected $fillable = [
         'user_id',
@@ -25,18 +29,6 @@ class UserVocabularyProgress extends Model
         'review_count',
         'last_reviewed_at',
     ];
-
-    public $incrementing = false;
-    protected $keyType = 'string';
-
-    protected static function booted()
-    {
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
 
     public function user()
     {

--- a/app/Models/Vocabulary.php
+++ b/app/Models/Vocabulary.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -19,7 +19,11 @@ use Illuminate\Support\Str;
  */
 class Vocabulary extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $table = 'vocabularies';
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     protected $fillable = [
         'teacher_id',
@@ -32,17 +36,9 @@ class Vocabulary extends Model
         'is_public',
     ];
 
-    public $incrementing = false;
-    protected $keyType = 'string';
-
-    protected static function booted()
-    {
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
+    protected $casts = [
+        'is_public' => 'boolean',
+    ];
 
     public function category()
     {

--- a/app/Models/VocabularyCategory.php
+++ b/app/Models/VocabularyCategory.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Str;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 
 /**
  * @property string $id
@@ -13,24 +13,16 @@ use Illuminate\Support\Str;
  */
 class VocabularyCategory extends Model
 {
-    use HasFactory;
+    use HasFactory, HasUuids;
+
+    protected $table = 'vocabulary_categories';
+    public $incrementing = false;
+    protected $keyType = 'string';
 
     protected $fillable = [
         'name',
         'color_code',
     ];
-
-    public $incrementing = false;
-    protected $keyType = 'string';
-
-    protected static function booted()
-    {
-        static::creating(function ($model) {
-            if (!$model->getKey()) {
-                $model->{$model->getKeyName()} = (string) Str::uuid();
-            }
-        });
-    }
 
     public function vocabularies()
     {

--- a/app/Models/WritingAssessment.php
+++ b/app/Models/WritingAssessment.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $user_id
+ * @property float $grammatical_range_accuracy_score
+ * @property float $lexical_resource_score
+ * @property float $coherence_cohesion_score
+ * @property float $task_response_score
+ * @property float $overall_score
+ * @property array $detailed_feedback
+ * @property array $error_analysis
+ * @property array $improvement_suggestions
+ * @property string $suggested_revision
+ * @property string $assessed_at
+ */
+class WritingAssessment extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'writing_assessments';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'user_id',
+        'grammatical_range_accuracy_score',
+        'lexical_resource_score',
+        'coherence_cohesion_score',
+        'task_response_score',
+        'overall_score',
+        'detailed_feedback',
+        'error_analysis',
+        'improvement_suggestions',
+        'suggested_revision',
+        'assessed_at',
+    ];
+
+    protected $casts = [
+        'grammatical_range_accuracy_score' => 'decimal:2',
+        'lexical_resource_score' => 'decimal:2',
+        'coherence_cohesion_score' => 'decimal:2',
+        'task_response_score' => 'decimal:2',
+        'overall_score' => 'decimal:2',
+        'detailed_feedback' => 'array',
+        'error_analysis' => 'array',
+        'assessed_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/app/Models/WritingSubmission.php
+++ b/app/Models/WritingSubmission.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+
+/**
+ * @property string $id
+ * @property string $session_id
+ * @property string $question_id
+ * @property string $user_id
+ * @property string $original_content
+ * @property string $revised_content
+ * @property int $word_count
+ * @property array $writing_analytics
+ * @property string $submitted_at
+ */
+class WritingSubmission extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $table = 'writing_submissions';
+    public $incrementing = false;
+    protected $keyType = 'string';
+
+    protected $fillable = [
+        'session_id',
+        'question_id',
+        'user_id',
+        'original_content',
+        'revised_content',
+        'word_count',
+        'writing_analytics',
+        'submitted_at',
+    ];
+
+    protected $casts = [
+        'writing_analytics' => 'array',
+        'submitted_at' => 'datetime',
+    ];
+
+    public function session()
+    {
+        return $this->belongsTo(TestSession::class, 'session_id');
+    }
+
+    public function question()
+    {
+        return $this->belongsTo(TestQuestion::class, 'question_id');
+    }
+
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/migrations/2025_07_24_043001_create_tests_table.php
+++ b/database/migrations/2025_07_24_043001_create_tests_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('creator_id');
+            $table->string('name');
+            $table->enum('type', ['reading', 'listening', 'speaking', 'writing']);
+            $table->enum('difficulty', ['beginner', 'intermediate', 'advanced']);
+            $table->text('description')->nullable();
+            $table->integer('time_limit_minutes')->default(0);
+            $table->integer('total_questions')->default(0);
+            $table->boolean('is_published')->default(false);
+            $table->boolean('is_public')->default(false);
+            $table->boolean('allow_repetition')->default(false);
+            $table->integer('max_repetition_count')->default(1);
+            $table->json('settings')->nullable();
+            $table->timestamps();
+
+            $table->foreign('creator_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tests');
+    }
+};

--- a/database/migrations/2025_07_24_045743_create_assignments_table.php
+++ b/database/migrations/2025_07_24_045743_create_assignments_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('assignments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('class_id');
+            $table->uuid('test_id');
+            $table->string('title');
+            $table->text('description')->nullable();
+            $table->timestamp('due_date')->nullable();
+            $table->timestamp('close_date')->nullable();
+            $table->boolean('is_published')->default(false);
+            $table->boolean('auto_grade')->default(false);
+            $table->boolean('allow_retake')->default(false);
+            $table->integer('max_attempts')->default(1);
+            $table->timestamps();
+
+            $table->foreign('class_id')->references('id')->on('classes')->onDelete('cascade');
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('assignments');
+    }
+};

--- a/database/migrations/2025_07_24_080552_create_test_passages_table.php
+++ b/database/migrations/2025_07_24_080552_create_test_passages_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('test_passages', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('test_id');
+            $table->integer('passage_number');
+            $table->string('title');
+            $table->text('content')->nullable();
+            $table->text('audio_file_path')->nullable();
+            $table->json('metadata')->nullable();
+            $table->timestamps();
+
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('test_passages');
+    }
+};

--- a/database/migrations/2025_07_24_080614_create_test_content_files_table.php
+++ b/database/migrations/2025_07_24_080614_create_test_content_files_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('test_content_files', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('test_id');
+            $table->string('filename');
+            $table->string('file_path');
+            $table->string('file_type');
+            $table->string('mime_type');
+            $table->bigInteger('file_size')->nullable();
+            $table->json('ocr_data')->nullable();
+            $table->timestamps();
+
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('test_content_files');
+    }
+};

--- a/database/migrations/2025_07_24_080810_create_test_sessions_table.php
+++ b/database/migrations/2025_07_24_080810_create_test_sessions_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('test_sessions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->uuid('test_id');
+            $table->uuid('assignment_id')->nullable();
+            $table->integer('attempt_number')->default(1);
+            $table->enum('test_type', ['reading','listening','speaking','writing']);
+            $table->json('session_data')->nullable();
+            $table->enum('status', ['in_progress','completed','abandoned'])->default('in_progress');
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('last_activity_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+            $table->foreign('assignment_id')->references('id')->on('assignments')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('test_sessions');
+    }
+};

--- a/database/migrations/2025_07_24_081210_create_question_types_table.php
+++ b/database/migrations/2025_07_24_081210_create_question_types_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_types', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->enum('category', ['reading', 'listening', 'speaking', 'writing']);
+            $table->json('template_structure')->nullable();
+            $table->json('scoring_rules')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_types');
+    }
+};

--- a/database/migrations/2025_07_24_081300_create_test_questions.php
+++ b/database/migrations/2025_07_24_081300_create_test_questions.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('test_questions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('test_id');
+            $table->uuid('passage_id')->nullable();
+            $table->uuid('question_type_id');
+            $table->uuid('question_instruction_id')->nullable();
+            $table->integer('question_number');
+            $table->string('question_group')->nullable();
+            $table->text('question_text');
+            $table->json('question_data')->nullable();
+            $table->json('correct_answers')->nullable();
+            $table->decimal('points_value', 8, 2)->default(0);
+            $table->text('explanation')->nullable();
+            $table->integer('audio_start_time')->nullable();
+            $table->integer('audio_end_time')->nullable();
+            $table->timestamps();
+
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+            $table->foreign('passage_id')->references('id')->on('test_passages')->onDelete('cascade');
+            $table->foreign('question_type_id')->references('id')->on('question_types')->onDelete('cascade');
+            $table->foreign('question_instruction_id')->references('id')->on('question_instructions')->onDelete('set null');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('test_questions');
+    }
+};

--- a/database/migrations/2025_07_24_134551_create_question_options_table.php
+++ b/database/migrations/2025_07_24_134551_create_question_options_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_options', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('question_id');
+            $table->string('option_key', 10);
+            $table->text('option_text');
+            $table->boolean('is_correct')->default(false);
+            $table->integer('display_order')->default(0);
+            $table->timestamps();
+
+            $table->foreign('question_id')->references('id')->on('test_questions')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_options');
+    }
+};

--- a/database/migrations/2025_07_24_134629_create_question_responses_table.php
+++ b/database/migrations/2025_07_24_134629_create_question_responses_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_responses', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('question_id');
+            $table->uuid('user_id');
+            $table->json('student_answer')->nullable();
+            $table->boolean('is_correct')->default(false);
+            $table->decimal('points_earned', 8, 2)->default(0);
+            $table->timestamp('answered_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('question_id')->references('id')->on('test_questions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_responses');
+    }
+};

--- a/database/migrations/2025_07_24_134703_create_audio_recordings_table.php
+++ b/database/migrations/2025_07_24_134703_create_audio_recordings_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('audio_recordings', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('question_id');
+            $table->uuid('user_id');
+            $table->string('audio_file_path');
+            $table->string('audio_format', 20);
+            $table->integer('duration_seconds')->nullable();
+            $table->text('transcript')->nullable();
+            $table->json('audio_analysis')->nullable();
+            $table->timestamp('recorded_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('question_id')->references('id')->on('test_questions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('audio_recordings');
+    }
+};

--- a/database/migrations/2025_07_24_143448_create_writing_submissions_table.php
+++ b/database/migrations/2025_07_24_143448_create_writing_submissions_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('writing_submissions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('question_id');
+            $table->uuid('user_id');
+            $table->text('original_content');
+            $table->text('revised_content')->nullable();
+            $table->integer('word_count')->default(0);
+            $table->json('writing_analytics')->nullable();
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('question_id')->references('id')->on('test_questions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('writing_submissions');
+    }
+};

--- a/database/migrations/2025_07_24_143516_create_test_results_table.php
+++ b/database/migrations/2025_07_24_143516_create_test_results_table.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('test_results', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('user_id');
+            $table->uuid('test_id');
+            $table->enum('test_type', ['reading', 'listening', 'speaking', 'writing']);
+            $table->decimal('total_score', 8, 2)->default(0);
+            $table->decimal('percentage_score', 5, 2)->default(0);
+            $table->integer('questions_correct')->default(0);
+            $table->integer('questions_incorrect')->default(0);
+            $table->integer('questions_missed')->default(0);
+            $table->json('detailed_breakdown')->nullable();
+            $table->json('performance_analytics')->nullable();
+            $table->timestamp('calculated_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('test_results');
+    }
+};

--- a/database/migrations/2025_07_24_143557_create_speaking_assessments_table.php
+++ b/database/migrations/2025_07_24_143557_create_speaking_assessments_table.php
@@ -1,0 +1,41 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('speaking_assessments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('user_id');
+            $table->decimal('fluency_coherence_score', 5, 2)->nullable();
+            $table->decimal('lexical_resource_score', 5, 2)->nullable();
+            $table->decimal('grammatical_range_accuracy_score', 5, 2)->nullable();
+            $table->decimal('pronunciation_score', 5, 2)->nullable();
+            $table->decimal('overall_score', 5, 2)->nullable();
+            $table->json('detailed_feedback')->nullable();
+            $table->json('grammar_analysis')->nullable();
+            $table->text('improvement_suggestions')->nullable();
+            $table->timestamp('assessed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('speaking_assessments');
+    }
+};

--- a/database/migrations/2025_07_24_143654_create_writing_assessments_table.php
+++ b/database/migrations/2025_07_24_143654_create_writing_assessments_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('writing_assessments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('session_id');
+            $table->uuid('user_id');
+            $table->decimal('grammatical_range_accuracy_score', 5, 2)->nullable();
+            $table->decimal('lexical_resource_score', 5, 2)->nullable();
+            $table->decimal('coherence_cohesion_score', 5, 2)->nullable();
+            $table->decimal('task_response_score', 5, 2)->nullable();
+            $table->decimal('overall_score', 5, 2)->nullable();
+            $table->json('detailed_feedback')->nullable();
+            $table->json('error_analysis')->nullable();
+            $table->text('improvement_suggestions')->nullable();
+            $table->text('suggested_revision')->nullable();
+            $table->timestamp('assessed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('session_id')->references('id')->on('test_sessions')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('writing_assessments');
+    }
+};

--- a/database/migrations/2025_07_24_154140_create_class_analytics_table.php
+++ b/database/migrations/2025_07_24_154140_create_class_analytics_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('class_analytics', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('class_id');
+            $table->uuid('assignment_id');
+            $table->decimal('average_score', 5, 2)->default(0);
+            $table->json('skill_breakdown')->nullable();
+            $table->json('performance_insights')->nullable();
+            $table->json('common_mistakes')->nullable();
+            $table->timestamp('calculated_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('class_id')->references('id')->on('classes')->onDelete('cascade');
+            $table->foreign('assignment_id')->references('id')->on('assignments')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('class_analytics');
+    }
+};

--- a/database/migrations/2025_07_24_154210_create_student_assignments_table.php
+++ b/database/migrations/2025_07_24_154210_create_student_assignments_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('student_assignments', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('assignment_id');
+            $table->uuid('student_id');
+            $table->enum('status', ['not_started','in_progress','completed','overdue'])->default('not_started');
+            $table->decimal('score', 5, 2)->nullable();
+            $table->integer('attempt_number')->default(0);
+            $table->json('submission_data')->nullable();
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamp('submitted_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('assignment_id')->references('id')->on('assignments')->onDelete('cascade');
+            $table->foreign('student_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('student_assignments');
+    }
+};

--- a/database/migrations/2025_07_24_154240_create_class_leaderboards_table.php
+++ b/database/migrations/2025_07_24_154240_create_class_leaderboards_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('class_leaderboards', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('class_id');
+            $table->uuid('assignment_id');
+            $table->uuid('student_id');
+            $table->decimal('score', 5, 2)->default(0);
+            $table->integer('rank_position')->nullable();
+            $table->enum('submission_status', ['on_time','late','unsubmitted'])->default('unsubmitted');
+            $table->timestamp('submission_date')->nullable();
+            $table->timestamps();
+
+            $table->foreign('class_id')->references('id')->on('classes')->onDelete('cascade');
+            $table->foreign('assignment_id')->references('id')->on('assignments')->onDelete('cascade');
+            $table->foreign('student_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('class_leaderboards');
+    }
+};

--- a/database/migrations/2025_07_25_065105_create_student_progress_table.php
+++ b/database/migrations/2025_07_25_065105_create_student_progress_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('student_progress', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->enum('skill_type', ['reading','listening','speaking','writing']);
+            $table->integer('tasks_completed')->default(0);
+            $table->integer('total_time_spent_seconds')->default(0);
+            $table->decimal('average_score', 5, 2)->default(0);
+            $table->json('monthly_performance')->nullable();
+            $table->json('weakest_question_types')->nullable();
+            $table->json('improvement_trends')->nullable();
+            $table->timestamp('last_updated')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('student_progress');
+    }
+};

--- a/database/migrations/2025_07_25_065118_create_question_type_performances_table.php
+++ b/database/migrations/2025_07_25_065118_create_question_type_performances_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_type_performances', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->string('question_type_name');
+            $table->enum('skill_category', ['reading','listening','speaking','writing']);
+            $table->integer('total_attempts')->default(0);
+            $table->integer('correct_answers')->default(0);
+            $table->decimal('accuracy_percentage', 5, 2)->default(0);
+            $table->json('performance_history')->nullable();
+            $table->timestamp('last_attempt')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_type_performances');
+    }
+};

--- a/database/migrations/2025_07_25_065132_create_public_tests_table.php
+++ b/database/migrations/2025_07_25_065132_create_public_tests_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('public_tests', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('admin_id');
+            $table->string('name');
+            $table->enum('type', ['reading','listening','speaking','writing']);
+            $table->enum('difficulty', ['beginner','intermediate','advanced']);
+            $table->text('description')->nullable();
+            $table->json('question_types')->nullable();
+            $table->boolean('is_published')->default(false);
+            $table->boolean('is_featured')->default(false);
+            $table->integer('total_attempts')->default(0);
+            $table->decimal('average_rating', 3, 2)->default(0);
+            $table->timestamp('published_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('admin_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('public_tests');
+    }
+};

--- a/database/migrations/2025_07_25_070836_create_public_test_attempts_table.php
+++ b/database/migrations/2025_07_25_070836_create_public_test_attempts_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('public_test_attempts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->uuid('public_test_id');
+            $table->decimal('score', 5, 2)->nullable();
+            $table->integer('time_spent_seconds')->default(0);
+            $table->json('performance_data')->nullable();
+            $table->decimal('rating', 3, 2)->nullable();
+            $table->text('feedback')->nullable();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('public_test_id')->references('id')->on('public_tests')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('public_test_attempts');
+    }
+};

--- a/database/migrations/2025_07_25_070847_create_teacher_dashboard_stats_table.php
+++ b/database/migrations/2025_07_25_070847_create_teacher_dashboard_stats_table.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teacher_dashboard_stats', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('teacher_id');
+            $table->integer('total_students')->default(0);
+            $table->integer('total_classes')->default(0);
+            $table->integer('total_tests_created')->default(0);
+            $table->integer('total_assignments')->default(0);
+            $table->json('monthly_activity')->nullable();
+            $table->json('class_performance_summary')->nullable();
+            $table->timestamp('last_calculated')->nullable();
+            $table->timestamps();
+
+            $table->foreign('teacher_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_dashboard_stats');
+    }
+};

--- a/database/migrations/2025_07_25_072024_create_social_accounts_table.php
+++ b/database/migrations/2025_07_25_072024_create_social_accounts_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('social_accounts', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->enum('provider', ['google', 'apple', 'facebook']);
+            $table->string('provider_id');
+            $table->string('provider_token');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('social_accounts');
+    }
+};

--- a/database/migrations/2025_07_25_072034_create_notifications_table.php
+++ b/database/migrations/2025_07_25_072034_create_notifications_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('notifications', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->enum('type', ['assignment','reminder','feedback','system']);
+            $table->string('title');
+            $table->text('message')->nullable();
+            $table->json('data')->nullable();
+            $table->boolean('is_read')->default(false);
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('notifications');
+    }
+};

--- a/database/migrations/2025_07_25_073526_create_teacher_plans_table.php
+++ b/database/migrations/2025_07_25_073526_create_teacher_plans_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teacher_plans', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->enum('name', ['Basic', 'Pro', 'Premium']);
+            $table->decimal('price', 8, 2)->default(0);
+            $table->integer('max_students')->default(0);
+            $table->integer('max_classrooms')->default(0);
+            $table->boolean('can_create_tests')->default(false);
+            $table->boolean('priority_support')->default(false);
+            $table->json('features')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_plans');
+    }
+};

--- a/database/migrations/2025_07_25_073536_create_teacher_subscriptions_table.php
+++ b/database/migrations/2025_07_25_073536_create_teacher_subscriptions_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teacher_subscriptions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('user_id');
+            $table->uuid('teacher_plan_id');
+            $table->timestamp('started_at')->nullable();
+            $table->timestamp('expires_at')->nullable();
+            $table->enum('status', ['active', 'expired', 'cancelled'])->default('active');
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->onDelete('cascade');
+            $table->foreign('teacher_plan_id')->references('id')->on('teacher_plans')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teacher_subscriptions');
+    }
+};

--- a/database/migrations/2025_07_25_073546_create_password_reset_tokens_table.php
+++ b/database/migrations/2025_07_25_073546_create_password_reset_tokens_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('password_reset_tokens', function (Blueprint $table) {
+            $table->string('email')->primary();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('password_reset_tokens');
+    }
+};

--- a/database/migrations/2025_07_28_133839_create_question_instructions_table.php
+++ b/database/migrations/2025_07_28_133839_create_question_instructions_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('question_instructions', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('test_id');
+            $table->uuid('question_type_id');
+            $table->text('instruction_text');
+            $table->timestamps();
+
+            $table->foreign('test_id')->references('id')->on('tests')->onDelete('cascade');
+            $table->foreign('question_type_id')->references('id')->on('question_types')->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('question_instructions');
+    }
+};

--- a/database/seeders/CategorySeeder.php
+++ b/database/seeders/CategorySeeder.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use App\Models\VocabularyCategory as Category;
+
+class CategorySeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        Category::updateOrCreate([
+            'name' => 'Noun',
+            'color_code' => '#FFC107'
+        ]);
+
+        Category::updateOrCreate([
+            'name' => 'Adjective',
+            'color_code' => '#EE47FF;
+'
+        ]);
+
+        Category::updateOrCreate([
+            'name' => 'Adverb',
+            'color_code' => '#0F68DC'
+        ]);
+
+        Category::updateOrCreate([
+            'name' => 'Verb',
+            'color_code' => '#50BFA5'
+        ]);
+    }
+}


### PR DESCRIPTION
### What’s added
- `app/Models/`: 30+ new model classes for assessment-related features, including:
  - `Test`, `TestPassage`, `TestSession`, `TestQuestion`, `TestResult`
  - `Assignment`, `StudentAssignment`, `StudentProgress`
  - `WritingAssessment`, `SpeakingAssessment`, `AudioRecording`, `WritingSubmission`
  - `QuestionType`, `QuestionOption`, `QuestionResponse`, `QuestionInstruction`, `QuestionTypePerformance`
  - `PublicTest`, `PublicTestAttempt`
  - `TeacherPlan`, `TeacherSubscription`, `TeacherDashboardStat`
  - `SocialAccount`, `Notification`, `PasswordResetToken`
  - `ClassAnalytic`, `ClassLeaderboard`
- `database/migrations/`: Matching migration files for all new models
- `database/seeders/CategorySeeder.php`: Seeder to populate initial vocabulary/test categories

### What’s changed
- Refactored existing model files to align with new model structure:
  - `ClassEnrollment.php`, `ClassInvitation.php`, `ClassVocabulary.php`, `Classes.php`
  - `UserVocabularyBookmark.php`, `UserVocabularyProgress.php`, `Vocabulary.php`, `VocabularyCategory.php`
- Updated common fields and structure:
  - Added `HasUuids`, set `$incrementing = false`, `$keyType = 'string'`, and standardized `$fillable`

### Notes
- All new models adopt UUID as primary key and follow consistent structure
- Seeder ensures development and test environments have necessary category data
- This structure is foundational for upcoming assessment and learning features (e.g., test flow, analytics, progress tracking)
