### PR TITLE
fix(auth): update Sanctum CSRF endpoint and CORS path configuration

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -245,7 +245,7 @@ class AuthController extends Controller
 
     /**
      * @OA\Get(
-     *     path="/api/sanctum/csrf-cookie",
+     *     path="/sanctum/csrf-cookie",
      *     summary="Get CSRF token cookie for Sanctum",
      *     tags={"Auth"},
      *     description="This endpoint sets the XSRF-TOKEN cookie required for CSRF protection in session-based auth. Usually called before login.",

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,7 +1,10 @@
 <?php
 
 return [
-    'paths' => ['api/*'],
+    'paths' => [
+        'api/*',
+        'sanctum/csrf-cookie',
+    ],
     'allowed_methods' => ['*'],
     'allowed_origins' => [
         'http://localhost:3000', // URL frontend

--- a/routes/web.php
+++ b/routes/web.php
@@ -34,4 +34,4 @@ Route::get('/api/test', function (Request $request) {
     return response()->json(['message' => 'API is working!']);
 });
 
-Route::get('/api/sanctum/csrf-cookie', [AuthController::class, 'sanctum']);
+Route::get('/sanctum/csrf-cookie', [AuthController::class, 'sanctum']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -327,14 +327,14 @@
                 ]
             }
         },
-        "/api/sanctum/csrf-cookie": {
+        "/sanctum/csrf-cookie": {
             "get": {
                 "tags": [
                     "Auth"
                 ],
                 "summary": "Get CSRF token cookie for Sanctum",
                 "description": "This endpoint sets the XSRF-TOKEN cookie required for CSRF protection in session-based auth. Usually called before login.",
-                "operationId": "f2a9c54baf087a62c063dd3417809b2d",
+                "operationId": "d5484dc25fb583625272d29e50a62548",
                 "responses": {
                     "204": {
                         "description": "CSRF cookie set successfully",


### PR DESCRIPTION
## 📌 Description

This PR updates the Sanctum CSRF cookie route and the CORS configuration to restore compatibility with Laravel's default expectations and improve frontend authentication behavior.

### Key Changes:
- Reverted custom CSRF cookie route from `/api/sanctum/csrf-cookie` back to Laravel’s default `/sanctum/csrf-cookie`.
- Updated `cors.php` to include `'sanctum/csrf-cookie'` in the `paths` array to allow proper cross-origin handling.

---

## ✅ To-Do List

- [x] Update Sanctum route to `/sanctum/csrf-cookie`
- [x] Adjust `cors.php` config:
  - Add `'sanctum/csrf-cookie'` to `paths`
- [x] Verify frontend can retrieve CSRF cookie without CORS issues
- [x] Ensure login flow works properly with CSRF token

---

## 🎯 Goal

Ensure that:
- The CSRF cookie can be accessed properly from the frontend (e.g., React, Vue)
- The route adheres to Sanctum’s default behavior for long-term maintainability
- No more 404 or CORS errors during authentication from browser-based clients

---

### ✅ Checklist Before Merge

- [x] CSRF token accessible from frontend via `/sanctum/csrf-cookie`
- [x] No CORS errors in browser console
- [x] `withCredentials` setup in frontend works as expected
- [x] Existing authentication flow tested successfully

---

### 🔗 Related Issue

Closes #8 
