### PR TITLE
feat(reading test): add reading test controller with centralized validation

### DIFF
--- a/app/Helpers/ValidationHelper.php
+++ b/app/Helpers/ValidationHelper.php
@@ -194,4 +194,114 @@ class ValidationHelper
             ]
         );
     }
+
+    public static function readingTest($data)
+    {
+        return Validator::make(
+            $data,
+            [
+                // General test information
+                'title' => 'required|string|max:255',
+                'description' => 'nullable|string',
+                'type' => 'required|in:reading,listening,speaking,writing', // Diperluas sesuai ERD
+                'difficulty' => 'required|in:beginner,intermediate,advanced',
+                'test_type' => 'required|in:single,final',
+                'timer_mode' => 'nullable|in:countdown,countup,none',
+                'timer_settings' => 'nullable|array',
+                'timer_settings.hours' => 'nullable|integer|min:0',
+                'timer_settings.minutes' => 'nullable|integer|min:0|max:59',
+                'timer_settings.seconds' => 'nullable|integer|min:0|max:59',
+                'allow_repetition' => 'nullable|boolean',
+                'max_repetition_count' => 'nullable|integer|min:1',
+                'is_public' => 'nullable|boolean',
+                'is_published' => 'nullable|boolean',
+                'settings' => 'nullable|array',
+
+                // Passages (array of passages)
+                'passages' => 'required|array|min:1',
+                'passages.*.title' => 'nullable|string|max:255',
+                'passages.*.description' => 'nullable|string',
+
+                // Question groups within each passage
+                'passages.*.question_groups' => 'required|array|min:1',
+                'passages.*.question_groups.*.instruction' => 'nullable|string',
+
+                // Questions within each question group
+                'passages.*.question_groups.*.questions' => 'required|array|min:1',
+                'passages.*.question_groups.*.questions.*.question_type' => 'required|string|max:255',
+                'passages.*.question_groups.*.questions.*.question_number' => 'nullable|numeric|min:1',
+                'passages.*.question_groups.*.questions.*.question_text' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.question_data' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.question_data.images.*' => 'nullable|file|mimes:jpeg,png,jpg|max:2048',
+                'passages.*.question_groups.*.questions.*.question_data.remove_images.*' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.correct_answers' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.points_value' => 'nullable|numeric|min:0',
+                'passages.*.question_groups.*.questions.*.options' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.options.*.option_key' => 'nullable|string|max:50',
+                'passages.*.question_groups.*.questions.*.options.*.option_text' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.breakdown' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.breakdown.explanation' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.breakdown.has_highlight' => 'nullable|boolean',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.start_char_index' => 'nullable|integer|min:0',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.end_char_index' => 'nullable|integer|min:0',
+
+                // Support for sub-questions (items) like in Matching Heading
+                'passages.*.question_groups.*.questions.*.items' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.items.*.question_number' => 'nullable|numeric|min:0.1',
+                'passages.*.question_groups.*.questions.*.items.*.question_text' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.items.*.correct_answers' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.items.*.points_value' => 'nullable|numeric|min:0',
+                'passages.*.question_groups.*.questions.*.items.*.options' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.items.*.options.*.option_key' => 'nullable|string|max:50',
+                'passages.*.question_groups.*.questions.*.items.*.options.*.option_text' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown.explanation' => 'nullable|string',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown.has_highlight' => 'nullable|boolean',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown.highlights' => 'nullable|array',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown.highlights.*.start_char_index' => 'nullable|integer|min:0',
+                'passages.*.question_groups.*.questions.*.items.*.breakdown.highlights.*.end_char_index' => 'nullable|integer|min:0',
+            ],
+            [
+                'title.required' => 'Test title is required.',
+                'title.max' => 'Test title cannot exceed 255 characters.',
+                'type.required' => 'Test type is required.',
+                'type.in' => 'Test type must be one of: reading, listening, speaking, writing.',
+                'difficulty.required' => 'Difficulty level is required.',
+                'difficulty.in' => 'Difficulty must be one of: beginner, intermediate, advanced.',
+                'test_type.required' => 'Test type (single/final) is required.',
+                'test_type.in' => 'Test type must be either "single" or "final".',
+                'timer_mode.in' => 'Timer mode must be one of: countdown, countup, none.',
+                'timer_settings.hours.integer' => 'Timer hours must be an integer.',
+                'timer_settings.hours.min' => 'Timer hours cannot be negative.',
+                'timer_settings.minutes.integer' => 'Timer minutes must be an integer.',
+                'timer_settings.minutes.min' => 'Timer minutes cannot be negative.',
+                'timer_settings.minutes.max' => 'Timer minutes cannot exceed 59.',
+                'timer_settings.seconds.integer' => 'Timer seconds must be an integer.',
+                'timer_settings.seconds.min' => 'Timer seconds cannot be negative.',
+                'timer_settings.seconds.max' => 'Timer seconds cannot exceed 59.',
+                'max_repetition_count.integer' => 'Max repetition count must be an integer.',
+                'max_repetition_count.min' => 'Max repetition count must be at least 1.',
+                'passages.required' => 'At least one passage is required.',
+                'passages.min' => 'At least one passage is required.',
+                'passages.*.title.max' => 'Passage title cannot exceed 255 characters.',
+                'passages.*.question_groups.required' => 'At least one question group is required per passage.',
+                'passages.*.question_groups.min' => 'At least one question group is required per passage.',
+                'passages.*.question_groups.*.questions.required' => 'At least one question is required per question group.',
+                'passages.*.question_groups.*.questions.min' => 'At least one question is required per question group.',
+                'passages.*.question_groups.*.questions.*.question_type.required' => 'Question type is required for each question.',
+                'passages.*.question_groups.*.questions.*.question_type.max' => 'Question type cannot exceed 255 characters.',
+                'passages.*.question_groups.*.questions.*.question_number.numeric' => 'Question number must be a number.',
+                'passages.*.question_groups.*.questions.*.question_number.min' => 'Question number must be at least 1.',
+                'passages.*.question_groups.*.questions.*.question_data.images.*.file' => 'The uploaded file must be an image.',
+                'passages.*.question_groups.*.questions.*.question_data.images.*.mimes' => 'The image must be a JPEG, PNG, or JPG file.',
+                'passages.*.question_groups.*.questions.*.question_data.images.*.max' => 'The image size cannot exceed 2MB.',
+                'passages.*.question_groups.*.questions.*.options.*.option_key.max' => 'Option key cannot exceed 50 characters.',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.start_char_index.integer' => 'Start character index must be an integer.',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.start_char_index.min' => 'Start character index cannot be negative.',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.end_char_index.integer' => 'End character index must be an integer.',
+                'passages.*.question_groups.*.questions.*.breakdown.highlights.*.end_char_index.min' => 'End character index cannot be negative.',
+            ]
+        );
+    }
 }

--- a/app/Http/Controllers/ReadingTestQuestionController.php
+++ b/app/Http/Controllers/ReadingTestQuestionController.php
@@ -1,0 +1,882 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Test;
+use App\Models\Passage;
+use App\Models\QuestionGroup;
+use App\Models\TestQuestion;
+use App\Models\QuestionOption;
+use App\Models\QuestionBreakdown;
+use App\Models\HighlightSegment;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\Helpers\ValidationHelper;
+use App\Helpers\FileUploadHelper;
+use Illuminate\Support\Facades\Log;
+
+class ReadingTestQuestionController extends Controller
+{
+    public function index(Request $request)
+    {
+        try {
+            $user = auth()->user();
+            $query = Test::query()->where('type', 'reading')
+                ->with([
+                    'passages.questionGroups.questions.options',
+                    'passages.questionGroups.questions.breakdowns.highlightSegments',
+                    'creator'
+                ]);
+
+            if ($user->role === 'admin') {
+                // Admins can access any test
+            } elseif ($user->role === 'student') {
+                // Students can only access published tests
+                $query->where('is_published', true);
+            } else {
+                // Non-admin, non-student users (e.g., teachers/creators) can only access their own tests
+                $query->where('creator_id', $user->id);
+            }
+
+            $tests = $query->get()->map(function ($test) use ($user) {
+                $isStudent = $user->role === 'student';
+                return [
+                    'id' => $test->id,
+                    'creator_id' => $test->creator_id,
+                    'creator_name' => $test->creator ? $test->creator->name : null,
+                    'test_type' => $test->test_type,
+                    'type' => $test->type,
+                    'difficulty' => $test->difficulty,
+                    'title' => $test->title,
+                    'description' => $test->description,
+                    'timer_mode' => $test->timer_mode,
+                    'timer_settings' => $test->timer_settings,
+                    'allow_repetition' => $test->allow_repetition,
+                    'max_repetition_count' => $test->max_repetition_count,
+                    'is_public' => $test->is_public,
+                    'is_published' => $test->is_published,
+                    'settings' => $test->settings,
+                    'created_at' => $test->created_at,
+                    'updated_at' => $test->updated_at,
+                    'passages' => $test->passages->map(function ($passage) use ($isStudent) {
+                        return [
+                            'passage_id' => $passage->id,
+                            'title' => $passage->title,
+                            'description' => $passage->description,
+                            'question_groups' => $passage->questionGroups->map(function ($group) use ($isStudent) {
+                                $questions = $group->questions;
+
+                                // Define the main question: the one without a dot (.)
+                                $mainQuestion = $questions->first(function ($q) {
+                                    return strpos((string)$q->question_number, '.') === false;
+                                });
+
+                                // fallback if there is no explicit main (e.g. all use 2.1, 2.2)
+                                if (!$mainQuestion) {
+                                    $mainQuestion = $questions->sortBy('question_number')->first();
+                                }
+
+                                if (!$mainQuestion || $mainQuestion->question_type !== 'Matching Heading') {
+                                    return [
+                                        'instruction' => $group->instruction,
+                                        'questions' => $questions->map(function ($question) use ($isStudent) {
+                                            $questionData = [
+                                                'question_id' => $question->id,
+                                                'question_type' => $question->question_type,
+                                                'question_number' => $question->question_number,
+                                                'question_text' => $question->question_text,
+                                                'question_data' => $question->question_data,
+                                                'points_value' => $question->points_value,
+                                                'options' => $question->options->map(function ($option) {
+                                                    return [
+                                                        'option_key' => $option->option_key,
+                                                        'option_text' => $option->option_text,
+                                                    ];
+                                                })->toArray(),
+                                            ];
+
+                                            if (!$isStudent) {
+                                                $correctAnswers = $question->correct_answers;
+                                                $decodedAnswers = is_array($correctAnswers) ? $correctAnswers : json_decode($correctAnswers, true) ?? [];
+                                                $questionData['correct_answers'] = count($decodedAnswers) === 1 ? $decodedAnswers[0] : $decodedAnswers;
+                                                $questionData['breakdown'] = $question->breakdowns->map(function ($breakdown) {
+                                                    $highlights = $breakdown->highlightSegments->map(function ($highlight) {
+                                                        return [
+                                                            'start_char_index' => $highlight->start_char_index,
+                                                            'end_char_index' => $highlight->end_char_index,
+                                                        ];
+                                                    })->toArray();
+                                                    return [
+                                                        'explanation' => $breakdown->explanation,
+                                                        'has_highlight' => $breakdown->has_highlight,
+                                                        'highlights' => count($highlights) === 1 ? $highlights[0] : $highlights,
+                                                    ];
+                                                })->first();
+                                            }
+
+                                            return $questionData;
+                                        })->toArray(),
+                                    ];
+                                }
+
+                                // Group items under the main question
+                                $items = $questions->filter(function ($q) use ($mainQuestion) {
+                                    return $q->id !== $mainQuestion->id && strpos((string)$q->question_number, '.') !== false;
+                                })->map(function ($item) use ($isStudent) {
+                                    $itemData = [
+                                        'question_id' => $item->id,
+                                        'question_number' => $item->question_number,
+                                        'question_text' => $item->question_text,
+                                    ];
+
+                                    if (!$isStudent) {
+                                        $itemData['correct_answers'] = json_decode($item->correct_answers, true);
+                                        $correctAnswers = $itemData['correct_answers'];
+                                        $itemData['correct_answers'] = count($correctAnswers) === 1 ? $correctAnswers[0] : $correctAnswers;
+                                        $itemData['breakdown'] = $item->breakdowns->map(function ($breakdown) {
+                                            $highlights = $breakdown->highlightSegments->map(function ($highlight) {
+                                                return [
+                                                    'start_char_index' => $highlight->start_char_index,
+                                                    'end_char_index' => $highlight->end_char_index,
+                                                ];
+                                            })->toArray();
+                                            return [
+                                                'explanation' => $breakdown->explanation,
+                                                'has_highlight' => $breakdown->has_highlight,
+                                                'highlights' => count($highlights) === 1 ? $highlights[0] : $highlights,
+                                            ];
+                                        })->first();
+                                    }
+
+                                    return $itemData;
+                                })->values();
+
+                                $mainQuestionData = [
+                                    'question_id' => $mainQuestion->id,
+                                    'question_type' => $mainQuestion->question_type,
+                                    'question_number' => $mainQuestion->question_number,
+                                    'question_data' => $mainQuestion->question_data,
+                                    'points_value' => $mainQuestion->points_value,
+                                    'options' => $mainQuestion->options->map(function ($option) {
+                                        return [
+                                            'option_key' => $option->option_key,
+                                            'option_text' => $option->option_text,
+                                        ];
+                                    })->toArray(),
+                                    'items' => $items->isNotEmpty() ? $items->toArray() : null,
+                                ];
+
+                                return [
+                                    'instruction' => $group->instruction,
+                                    'questions' => [$mainQuestionData],
+                                ];
+                            })->toArray(),
+                        ];
+                    })->toArray(),
+                ];
+            });
+
+            return response()->json([
+                'message' => 'Reading tests retrieved successfully',
+                'data' => $tests,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Failed to retrieve reading tests',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function store(Request $request)
+    {
+        $validator = ValidationHelper::readingTest($request->all());
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $validated = $validator->validated();
+
+        try {
+            DB::beginTransaction();
+
+            // Create the test
+            $test = Test::create([
+                'id' => (string) Str::uuid(),
+                'creator_id' => auth()->id(),
+                'type' => $validated['type'],
+                'difficulty' => $validated['difficulty'],
+                'title' => $validated['title'],
+                'description' => $validated['description'] ?? null,
+                'test_type' => $validated['test_type'] ?? 'single',
+                'timer_mode' => $validated['timer_mode'] ?? 'none',
+                'timer_settings' => $validated['timer_settings'] ?? null,
+                'allow_repetition' => $validated['allow_repetition'] ?? false,
+                'max_repetition_count' => $validated['max_repetition_count'] ?? null,
+                'is_public' => $validated['is_public'] ?? false,
+                'is_published' => $validated['is_published'] ?? true,
+                'settings' => $validated['settings'] ?? null,
+            ]);
+
+            // Process each passage
+            foreach ($validated['passages'] as $passageIndex => $passageData) {
+                $passage = Passage::create([
+                    'id' => (string) Str::uuid(),
+                    'test_id' => $test->id,
+                    'title' => $passageData['title'] ?? null,
+                    'description' => $passageData['description'] ?? null,
+                ]);
+
+                foreach ($passageData['question_groups'] as $groupIndex => $groupData) {
+                    $questionGroup = QuestionGroup::create([
+                        'id' => (string) Str::uuid(),
+                        'passage_id' => $passage->id,
+                        'instruction' => $groupData['instruction'] ?? null,
+                    ]);
+
+                    foreach ($groupData['questions'] as $questionIndex => $questionData) {
+                        $imageKey = "passages.{$passageIndex}.question_groups.{$groupIndex}.questions.{$questionIndex}.question_data.images";
+                        $newImagePaths = [];
+                        if ($request->hasFile($imageKey)) {
+                            foreach ($request->file($imageKey) as $image) {
+                                $newImagePaths[] = FileUploadHelper::upload($image, 'question_images');
+                            }
+                        }
+
+                        $questionDataArray = $questionData['question_data'] ?? [];
+                        unset($questionDataArray['images']);
+
+                        $question = TestQuestion::create([
+                            'id' => (string) Str::uuid(),
+                            'question_group_id' => $questionGroup->id,
+                            'question_type' => $questionData['question_type'],
+                            'question_number' => $questionData['question_number'] ?? null,
+                            'question_text' => $questionData['question_text'] ?? null,
+                            'question_data' => array_merge(
+                                $questionDataArray,
+                                $newImagePaths ? ['image_path' => $newImagePaths] : []
+                            ),
+                            'correct_answers' => json_encode($questionData['correct_answers'] ?? []),
+                            'points_value' => $questionData['points_value'] ?? 0,
+                        ]);
+
+                        if (isset($questionData['options'])) {
+                            foreach ($questionData['options'] as $optionData) {
+                                QuestionOption::create([
+                                    'id' => (string) Str::uuid(),
+                                    'question_id' => $question->id,
+                                    'option_key' => $optionData['option_key'] ?? null,
+                                    'option_text' => $optionData['option_text'] ?? null,
+                                ]);
+                            }
+                        }
+
+                        // Handle items if present (for types like Matching Heading)
+                        if (isset($questionData['items'])) {
+                            foreach ($questionData['items'] as $itemIndex => $itemData) {
+                                $subQuestion = TestQuestion::create([
+                                    'id' => (string) Str::uuid(),
+                                    'question_group_id' => $questionGroup->id,
+                                    'question_type' => $questionData['question_type'],
+                                    'question_number' => $itemData['question_number'] ?? null,
+                                    'question_text' => $itemData['question_text'] ?? null,
+                                    'question_data' => $itemData['question_data'] ?? [],
+                                    'correct_answers' => json_encode($itemData['correct_answers'] ?? []),
+                                ]);
+
+                                if (isset($itemData['options'])) {
+                                    foreach ($itemData['options'] as $optionData) {
+                                        QuestionOption::create([
+                                            'id' => (string) Str::uuid(),
+                                            'question_id' => $subQuestion->id,
+                                            'option_key' => $optionData['option_key'] ?? null,
+                                            'option_text' => $optionData['option_text'] ?? null,
+                                        ]);
+                                    }
+                                }
+
+                                if (isset($itemData['breakdown'])) {
+                                    $breakdown = QuestionBreakdown::create([
+                                        'id' => (string) Str::uuid(),
+                                        'question_id' => $subQuestion->id,
+                                        'explanation' => $itemData['breakdown']['explanation'] ?? null,
+                                        'has_highlight' => $itemData['breakdown']['has_highlight'] ?? false,
+                                    ]);
+
+                                    if (isset($itemData['breakdown']['highlights'])) {
+                                        foreach ($itemData['breakdown']['highlights'] as $highlightData) {
+                                            HighlightSegment::create([
+                                                'id' => (string) Str::uuid(),
+                                                'breakdown_id' => $breakdown->id,
+                                                'start_char_index' => $highlightData['start_char_index'] ?? null,
+                                                'end_char_index' => $highlightData['end_char_index'] ?? null,
+                                            ]);
+                                        }
+                                    }
+                                }
+                            }
+                        } else {
+                            if (isset($questionData['breakdown'])) {
+                                $breakdown = QuestionBreakdown::create([
+                                    'id' => (string) Str::uuid(),
+                                    'question_id' => $question->id,
+                                    'explanation' => $questionData['breakdown']['explanation'] ?? null,
+                                    'has_highlight' => $questionData['breakdown']['has_highlight'] ?? false,
+                                ]);
+
+                                if (isset($questionData['breakdown']['highlights'])) {
+                                    foreach ($questionData['breakdown']['highlights'] as $highlightData) {
+                                        HighlightSegment::create([
+                                            'id' => (string) Str::uuid(),
+                                            'breakdown_id' => $breakdown->id,
+                                            'start_char_index' => $highlightData['start_char_index'] ?? null,
+                                            'end_char_index' => $highlightData['end_char_index'] ?? null,
+                                        ]);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            DB::commit();
+
+            return response()->json([
+                'message' => 'Reading test created successfully',
+                'test_id' => $test->id,
+            ], 201);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'message' => 'Failed to create reading test',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function show(Request $request, $id)
+    {
+        try {
+            $user = auth()->user();
+            $query = Test::query()->where('type', 'reading')
+                ->where('id', $id)
+                ->with([
+                    'passages.questionGroups.questions.options',
+                    'passages.questionGroups.questions.breakdowns.highlightSegments',
+                    'creator'
+                ]);
+
+            // Apply role-based access control
+            if ($user->role === 'admin') {
+                // Admins can access any test
+            } elseif ($user->role === 'student') {
+                // Students can only access published tests
+                $query->where('is_published', true);
+            } else {
+                // Non-admin, non-student users (e.g., teachers/creators) can only access their own tests
+                $query->where('creator_id', $user->id);
+            }
+
+            $test = $query->first();
+
+            // Check if test exists and is accessible
+            if (!$test) {
+                return response()->json([
+                    'message' => 'Test not found or unauthorized access',
+                ], 404);
+            }
+
+            $isStudent = $user->role === 'student';
+            $testData = [
+                'id' => $test->id,
+                'creator_id' => $test->creator_id,
+                'creator_name' => $test->creator ? $test->creator->name : null,
+                'test_type' => $test->test_type,
+                'type' => $test->type,
+                'difficulty' => $test->difficulty,
+                'title' => $test->title,
+                'description' => $test->description,
+                'timer_mode' => $test->timer_mode,
+                'timer_settings' => $test->timer_settings,
+                'allow_repetition' => $test->allow_repetition,
+                'max_repetition_count' => $test->max_repetition_count,
+                'is_public' => $test->is_public,
+                'is_published' => $test->is_published,
+                'settings' => $test->settings,
+                'created_at' => $test->created_at,
+                'updated_at' => $test->updated_at,
+                'passages' => $test->passages->map(function ($passage) use ($isStudent) {
+                    return [
+                        'passage_id' => $passage->id,
+                        'title' => $passage->title,
+                        'description' => $passage->description,
+                        'question_groups' => $passage->questionGroups->map(function ($group) use ($isStudent) {
+                            $questions = $group->questions;
+
+                            // Define the main question: the one without a dot (.)
+                            $mainQuestion = $questions->first(function ($q) {
+                                return strpos((string)$q->question_number, '.') === false;
+                            });
+
+                            // fallback if there is no explicit main (e.g. all use 2.1, 2.2)
+                            if (!$mainQuestion) {
+                                $mainQuestion = $questions->sortBy('question_number')->first();
+                            }
+
+                            if (!$mainQuestion || $mainQuestion->question_type !== 'Matching Heading') {
+                                return [
+                                    'instruction' => $group->instruction,
+                                    'questions' => $questions->map(function ($question) use ($isStudent) {
+                                        $questionData = [
+                                            'question_id' => $question->id,
+                                            'question_type' => $question->question_type,
+                                            'question_number' => $question->question_number,
+                                            'question_text' => $question->question_text,
+                                            'question_data' => $question->question_data,
+                                            'points_value' => $question->points_value,
+                                            'options' => $question->options->map(function ($option) {
+                                                return [
+                                                    'option_key' => $option->option_key,
+                                                    'option_text' => $option->option_text,
+                                                ];
+                                            })->toArray(),
+                                        ];
+
+                                        if (!$isStudent) {
+                                            $correctAnswers = $question->correct_answers;
+                                            $decodedAnswers = is_array($correctAnswers) ? $correctAnswers : json_decode($correctAnswers, true) ?? [];
+                                            $questionData['correct_answers'] = count($decodedAnswers) === 1 ? $decodedAnswers[0] : $decodedAnswers;
+                                            $questionData['breakdown'] = $question->breakdowns->map(function ($breakdown) {
+                                                $highlights = $breakdown->highlightSegments->map(function ($highlight) {
+                                                    return [
+                                                        'start_char_index' => $highlight->start_char_index,
+                                                        'end_char_index' => $highlight->end_char_index,
+                                                    ];
+                                                })->toArray();
+                                                return [
+                                                    'explanation' => $breakdown->explanation,
+                                                    'has_highlight' => $breakdown->has_highlight,
+                                                    'highlights' => count($highlights) === 1 ? $highlights[0] : $highlights,
+                                                ];
+                                            })->first();
+                                        }
+
+                                        return $questionData;
+                                    })->toArray(),
+                                ];
+                            }
+
+                            // Group items under the main question
+                            $items = $questions->filter(function ($q) use ($mainQuestion) {
+                                return $q->id !== $mainQuestion->id && strpos((string)$q->question_number, '.') !== false;
+                            })->map(function ($item) use ($isStudent) {
+                                $itemData = [
+                                    'question_id' => $item->id,
+                                    'question_number' => $item->question_number,
+                                    'question_text' => $item->question_text,
+                                ];
+
+                                if (!$isStudent) {
+                                    $itemData['correct_answers'] = json_decode($item->correct_answers, true);
+                                    $correctAnswers = $itemData['correct_answers'];
+                                    $itemData['correct_answers'] = count($correctAnswers) === 1 ? $correctAnswers[0] : $correctAnswers;
+                                    $itemData['breakdown'] = $item->breakdowns->map(function ($breakdown) {
+                                        $highlights = $breakdown->highlightSegments->map(function ($highlight) {
+                                            return [
+                                                'start_char_index' => $highlight->start_char_index,
+                                                'end_char_index' => $highlight->end_char_index,
+                                            ];
+                                        })->toArray();
+                                        return [
+                                            'explanation' => $breakdown->explanation,
+                                            'has_highlight' => $breakdown->has_highlight,
+                                            'highlights' => count($highlights) === 1 ? $highlights[0] : $highlights,
+                                        ];
+                                    })->first();
+                                }
+
+                                return $itemData;
+                            })->values();
+
+                            $mainQuestionData = [
+                                'question_id' => $mainQuestion->id,
+                                'question_type' => $mainQuestion->question_type,
+                                'question_number' => $mainQuestion->question_number,
+                                'question_data' => $mainQuestion->question_data,
+                                'points_value' => $mainQuestion->points_value,
+                                'options' => $mainQuestion->options->map(function ($option) {
+                                    return [
+                                        'option_key' => $option->option_key,
+                                        'option_text' => $option->option_text,
+                                    ];
+                                })->toArray(),
+                                'items' => $items->isNotEmpty() ? $items->toArray() : null,
+                            ];
+
+                            return [
+                                'instruction' => $group->instruction,
+                                'questions' => [$mainQuestionData],
+                            ];
+                        })->toArray(),
+                    ];
+                })->toArray(),
+            ];
+
+            return response()->json([
+                'message' => 'Reading test retrieved successfully',
+                'data' => $testData,
+            ], 200);
+        } catch (\Exception $e) {
+            return response()->json([
+                'message' => 'Failed to retrieve reading test',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function update(Request $request, $id)
+    {
+        $test = Test::find($id);
+        if (!$test) {
+            return response()->json(['message' => 'Test not found'], 404);
+        }
+
+        if ($test->creator_id !== auth()->user()->id && auth()->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized to update this test'], 403);
+        }
+
+        $validator = ValidationHelper::readingTest($request->all());
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $validated = $validator->validated();
+
+        try {
+            DB::beginTransaction();
+
+            // update main test
+            $test->update([
+                'difficulty' => $validated['difficulty'],
+                'title' => $validated['title'],
+                'description' => $validated['description'] ?? null,
+                'test_type' => $validated['test_type'] ?? $test->test_type,
+                'timer_mode' => $validated['timer_mode'] ?? $test->timer_mode,
+                'timer_settings' => $validated['timer_settings'] ?? null,
+                'allow_repetition' => $validated['allow_repetition'] ?? false,
+                'max_repetition_count' => $validated['max_repetition_count'] ?? null,
+                'is_public' => $validated['is_public'] ?? false,
+                'is_published' => $validated['is_published'] ?? $test->is_published,
+                'settings' => $validated['settings'] ?? $test->settings,
+            ]);
+
+            $existingPassageIds = [];
+
+            foreach ($validated['passages'] as $pIndex => $pData) {
+                $passage = Passage::updateOrCreate(
+                    ['id' => $pData['id'] ?? null],
+                    [
+                        'id' => $pData['id'] ?? (string) Str::uuid(),
+                        'test_id' => $test->id,
+                        'title' => $pData['title'] ?? null,
+                        'description' => $pData['description'] ?? null,
+                    ]
+                );
+                $existingPassageIds[] = $passage->id;
+
+                $existingGroupIds = [];
+
+                foreach ($pData['question_groups'] as $gIndex => $gData) {
+                    $group = QuestionGroup::updateOrCreate(
+                        ['id' => $gData['id'] ?? null],
+                        [
+                            'id' => $gData['id'] ?? (string) Str::uuid(),
+                            'passage_id' => $passage->id,
+                            'instruction' => $gData['instruction'] ?? null,
+                        ]
+                    );
+                    $existingGroupIds[] = $group->id;
+
+                    $existingQuestionIds = [];
+
+                    foreach ($gData['questions'] as $qIndex => $qData) {
+                        $imageKey = "passages.$pIndex.question_groups.$gIndex.questions.$qIndex.question_data.images";
+
+                        $question = TestQuestion::updateOrCreate(
+                            ['id' => $qData['id'] ?? null],
+                            [
+                                'id' => $qData['id'] ?? (string) Str::uuid(),
+                                'question_group_id' => $group->id,
+                                'question_type' => $qData['question_type'],
+                                'question_number' => $qData['question_number'] ?? null,
+                                'question_text' => $qData['question_text'] ?? null,
+                                'points_value' => $qData['points_value'] ?? 0,
+                            ]
+                        );
+
+                        // ambil data lama
+                        $currentData = is_array($question->question_data) ? $question->question_data : [];
+                        $currentPaths = $currentData['image_path'] ?? [];
+
+                        // upload baru
+                        $newPaths = [];
+                        if ($request->hasFile($imageKey)) {
+                            // hapus lama
+                            foreach ($currentPaths as $old) {
+                                FileUploadHelper::delete(str_replace('/storage/', '', $old));
+                            }
+                            $currentPaths = [];
+                            foreach ($request->file($imageKey) as $img) {
+                                $newPaths[] = FileUploadHelper::upload($img, 'question_images');
+                            }
+                        }
+
+                        // remove_images
+                        $removeImages = $qData['question_data']['remove_images'] ?? [];
+                        if ($removeImages && !$newPaths) {
+                            foreach ($removeImages as $rm) {
+                                FileUploadHelper::delete(str_replace('/storage/', '', $rm));
+                            }
+                            $currentPaths = array_values(array_diff($currentPaths, $removeImages));
+                        }
+
+                        $finalPaths = $newPaths ?: $currentPaths;
+
+                        $newQData = $qData['question_data'] ?? [];
+                        unset($newQData['images'], $newQData['remove_images']);
+
+                        $question->update([
+                            'question_data' => array_merge($newQData, $finalPaths ? ['image_path' => $finalPaths] : []),
+                            'correct_answers' => $qData['correct_answers'] ?? $question->correct_answers,
+                        ]);
+
+                        $existingQuestionIds[] = $question->id;
+
+                        // handle options
+                        if (isset($qData['options'])) {
+                            $optionIds = [];
+                            foreach ($qData['options'] as $oData) {
+                                $opt = QuestionOption::updateOrCreate(
+                                    ['id' => $oData['id'] ?? null],
+                                    [
+                                        'id' => $oData['id'] ?? (string) Str::uuid(),
+                                        'question_id' => $question->id,
+                                        'option_key' => $oData['option_key'],
+                                        'option_text' => $oData['option_text'] ?? null,
+                                    ]
+                                );
+                                $optionIds[] = $opt->id;
+                            }
+                            QuestionOption::where('question_id', $question->id)
+                                ->whereNotIn('id', $optionIds)
+                                ->delete();
+                        }
+
+                        // handle breakdown
+                        if (isset($qData['breakdown'])) {
+                            $breakdown = QuestionBreakdown::updateOrCreate(
+                                ['question_id' => $question->id],
+                                [
+                                    'id' => $qData['breakdown']['id'] ?? (string) Str::uuid(),
+                                    'explanation' => $qData['breakdown']['explanation'] ?? null,
+                                    'has_highlight' => $qData['breakdown']['has_highlight'] ?? false,
+                                ]
+                            );
+
+                            if (isset($qData['breakdown']['highlights'])) {
+                                $highlightIds = [];
+                                foreach ($qData['breakdown']['highlights'] as $hData) {
+                                    $h = HighlightSegment::updateOrCreate(
+                                        ['id' => $hData['id'] ?? null],
+                                        [
+                                            'id' => $hData['id'] ?? (string) Str::uuid(),
+                                            'breakdown_id' => $breakdown->id,
+                                            'start_char_index' => $hData['start_char_index'],
+                                            'end_char_index' => $hData['end_char_index'],
+                                        ]
+                                    );
+                                    $highlightIds[] = $h->id;
+                                }
+                                HighlightSegment::where('breakdown_id', $breakdown->id)
+                                    ->whereNotIn('id', $highlightIds)
+                                    ->delete();
+                            }
+                        }
+                    }
+
+                    TestQuestion::where('question_group_id', $group->id)
+                        ->whereNotIn('id', $existingQuestionIds)
+                        ->delete();
+                }
+
+                QuestionGroup::where('passage_id', $passage->id)
+                    ->whereNotIn('id', $existingGroupIds)
+                    ->delete();
+            }
+
+            Passage::where('test_id', $test->id)
+                ->whereNotIn('id', $existingPassageIds)
+                ->delete();
+
+            DB::commit();
+            return response()->json(['message' => 'Reading test updated successfully', 'test_id' => $test->id], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json(['message' => 'Failed to update reading test', 'error' => $e->getMessage()], 500);
+        }
+    }
+
+    public function deletePassage($passageId)
+    {
+        $passage = Passage::find($passageId);
+        if (!$passage) {
+            return response()->json(['message' => 'Passage not found'], 404);
+        }
+
+        $test = $passage->test;
+        if ($test->creator_id !== auth()->user()->id && auth()->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized to delete this passage'], 403);
+        }
+
+        try {
+            DB::beginTransaction();
+
+            // Get all the questions in the passage
+            $questions = TestQuestion::whereHas('questionGroup', function ($query) use ($passageId) {
+                $query->where('passage_id', $passageId);
+            })->get();
+
+            // Remove related images from each question
+            foreach ($questions as $question) {
+                if (isset($question->question_data['image_path'])) {
+                    $imagePaths = is_array($question->question_data['image_path'])
+                        ? $question->question_data['image_path']
+                        : [$question->question_data['image_path']];
+                    foreach ($imagePaths as $path) {
+                        $deletePath = str_replace('/storage/', '', $path);
+                        FileUploadHelper::delete($deletePath);
+                    }
+                }
+            }
+
+            // Delete passage (cascade will delete question groups and questions)
+            $passage->delete();
+
+            DB::commit();
+
+            return response()->json([
+                'message' => 'Passage and its contents deleted successfully',
+            ], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'message' => 'Failed to delete passage',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function deleteQuestion($questionId)
+    {
+        $question = TestQuestion::find($questionId);
+        if (!$question) {
+            return response()->json(['message' => 'Question not found'], 404);
+        }
+
+        $questionGroup = $question->questionGroup;
+        $test = $questionGroup->passage->test;
+
+        if ($test->creator_id !== auth()->user()->id && auth()->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized to delete this question'], 403);
+        }
+
+        try {
+            DB::beginTransaction();
+
+            // Delete associated images if they exist
+            if (isset($question->question_data['image_path'])) {
+                $imagePaths = is_array($question->question_data['image_path'])
+                    ? $question->question_data['image_path']
+                    : [$question->question_data['image_path']];
+                foreach ($imagePaths as $path) {
+                    $deletePath = str_replace('/storage/', '', $path);
+                    FileUploadHelper::delete($deletePath);
+                }
+            }
+
+            // Delete the question (cascades to options, breakdowns, highlights via onDelete('cascade'))
+            $question->delete();
+
+            // Check if the question group has any remaining questions
+            $remainingQuestions = TestQuestion::where('question_group_id', $questionGroup->id)->count();
+            $deletedGroup = false;
+            if ($remainingQuestions === 0) {
+                $questionGroup->delete();
+                $deletedGroup = true;
+            }
+
+            DB::commit();
+
+            return response()->json([
+                'message' => $deletedGroup
+                    ? 'Question and its empty question group deleted successfully'
+                    : 'Question deleted successfully',
+                'question_group_deleted' => $deletedGroup,
+            ], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'message' => 'Failed to delete question',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+
+    public function destroy($id)
+    {
+        $test = Test::find($id);
+        if (!$test) {
+            return response()->json(['message' => 'Test not found'], 404);
+        }
+
+        if ($test->creator_id !== auth()->user()->id && auth()->user()->role !== 'admin') {
+            return response()->json(['message' => 'Unauthorized to delete this test'], 403);
+        }
+
+        try {
+            DB::beginTransaction();
+
+            $questions = TestQuestion::whereHas('questionGroup.passage', function ($query) use ($id) {
+                $query->where('test_id', $id);
+            })->get();
+
+            foreach ($questions as $question) {
+                if (isset($question->question_data['image_path'])) {
+                    $imagePaths = is_array($question->question_data['image_path'])
+                        ? $question->question_data['image_path']
+                        : [$question->question_data['image_path']];
+                    foreach ($imagePaths as $path) {
+                        $deletePath = str_replace('/storage/', '', $path);
+                        FileUploadHelper::delete($deletePath);
+                    }
+                }
+            }
+
+            $test->delete();
+
+            DB::commit();
+
+            return response()->json([
+                'message' => 'Reading test deleted successfully',
+            ], 200);
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return response()->json([
+                'message' => 'Failed to delete reading test',
+                'error' => $e->getMessage(),
+            ], 500);
+        }
+    }
+}

--- a/app/Models/HighlightSegment.php
+++ b/app/Models/HighlightSegment.php
@@ -9,11 +9,8 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 /**
  * @property string $id
  * @property string $breakdown_id
- * @property string $passage_type
  * @property int|null $start_char_index
  * @property int|null $end_char_index
- * @property float|null $start_time_seconds
- * @property float|null $end_time_seconds
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */
@@ -30,14 +27,10 @@ class HighlightSegment extends Model
         'passage_type',
         'start_char_index',
         'end_char_index',
-        'start_time_seconds',
-        'end_time_seconds',
     ];
 
     protected $casts = [
         'passage_type' => 'string',
-        'start_time_seconds' => 'float',
-        'end_time_seconds' => 'float',
     ];
 
     public function breakdown()

--- a/app/Models/QuestionGroup.php
+++ b/app/Models/QuestionGroup.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 /**
  * @property string $id
  * @property string $passage_id
- * @property string $question_type
  * @property string|null $instruction
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
@@ -24,12 +23,7 @@ class QuestionGroup extends Model
 
     protected $fillable = [
         'passage_id',
-        'question_type',
         'instruction',
-    ];
-
-    protected $casts = [
-        'question_type' => 'string',
     ];
 
     public function passage()
@@ -39,6 +33,6 @@ class QuestionGroup extends Model
 
     public function questions()
     {
-        return $this->hasMany(TestQuestion::class, 'question_group_id');
+        return $this->hasMany(TestQuestion::class, 'question_group_id', 'id');
     }
 }

--- a/app/Models/QuestionOption.php
+++ b/app/Models/QuestionOption.php
@@ -11,8 +11,6 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
  * @property string $question_id
  * @property string|null $option_key
  * @property string|null $option_text
- * @property bool $is_correct
- * @property int|null $display_order
  * @property \Carbon\Carbon $created_at
  * @property \Carbon\Carbon $updated_at
  */
@@ -28,12 +26,6 @@ class QuestionOption extends Model
         'question_id',
         'option_key',
         'option_text',
-        'is_correct',
-        'display_order',
-    ];
-
-    protected $casts = [
-        'is_correct' => 'boolean',
     ];
 
     public function question()

--- a/app/Models/Test.php
+++ b/app/Models/Test.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
  * @property string $difficulty
  * @property string $title
  * @property string|null $description
+ * @property string $test_type
  * @property string|null $timer_mode
  * @property array|null $timer_settings
  * @property bool $allow_repetition
@@ -37,6 +38,7 @@ class Test extends Model
         'difficulty',
         'title',
         'description',
+        'test_type',
         'timer_mode',
         'timer_settings',
         'allow_repetition',

--- a/app/Models/TestQuestion.php
+++ b/app/Models/TestQuestion.php
@@ -9,7 +9,8 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 /**
  * @property string $id
  * @property string $question_group_id
- * @property int|null $question_number
+ * @property string $question_type
+ * @property float|null $question_number
  * @property string|null $question_text
  * @property array|null $question_data
  * @property array|null $correct_answers
@@ -27,6 +28,7 @@ class TestQuestion extends Model
 
     protected $fillable = [
         'question_group_id',
+        'question_type',
         'question_number',
         'question_text',
         'question_data',
@@ -35,6 +37,7 @@ class TestQuestion extends Model
     ];
 
     protected $casts = [
+        'question_number' => 'float',
         'question_data' => 'array',
         'correct_answers' => 'array',
         'points_value' => 'float',
@@ -42,7 +45,7 @@ class TestQuestion extends Model
 
     public function questionGroup()
     {
-        return $this->belongsTo(QuestionGroup::class, 'question_group_id');
+        return $this->belongsTo(QuestionGroup::class, 'question_group_id', 'id');
     }
 
     public function options()

--- a/database/migrations/2025_08_11_060032_create_test_system_table.php
+++ b/database/migrations/2025_08_11_060032_create_test_system_table.php
@@ -14,10 +14,11 @@ return new class extends Migration
         Schema::create('tests', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('creator_id');
-            $table->enum('type', ['reading','listening','speaking','writing']);
             $table->enum('difficulty', ['beginner','intermediate','advanced'])->default('beginner');
             $table->string('title');
             $table->text('description')->nullable();
+            $table->enum('type', ['reading','listening','speaking','writing']);
+            $table->enum('test_type', ['single', 'final'])->default('single');
             $table->enum('timer_mode', ['countdown', 'countup', 'none'])->default('none');
             $table->json('timer_settings')->nullable();
             $table->boolean('allow_repetition')->default(false);
@@ -46,7 +47,6 @@ return new class extends Migration
         Schema::create('question_groups', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('passage_id');
-            $table->string('question_type');
             $table->text('instruction')->nullable();
             $table->timestamps();
 
@@ -56,7 +56,8 @@ return new class extends Migration
         Schema::create('test_questions', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('question_group_id');
-            $table->integer('question_number')->nullable();
+            $table->string('question_type');
+            $table->float('question_number')->nullable();
             $table->text('question_text')->nullable();
             $table->json('question_data')->nullable();
             $table->json('correct_answers')->nullable();
@@ -71,8 +72,6 @@ return new class extends Migration
             $table->uuid('question_id');
             $table->string('option_key')->nullable();
             $table->text('option_text')->nullable();
-            $table->boolean('is_correct')->default(false);
-            $table->integer('display_order')->nullable();
             $table->timestamps();
 
             $table->foreign('question_id')->references('id')->on('test_questions')->cascadeOnDelete();

--- a/database/migrations/2025_08_11_064828_create_question_breakdown_table.php
+++ b/database/migrations/2025_08_11_064828_create_question_breakdown_table.php
@@ -24,11 +24,8 @@ return new class extends Migration
         Schema::create('highlight_segments', function (Blueprint $table) {
             $table->uuid('id')->primary();
             $table->uuid('breakdown_id');
-            $table->enum('passage_type', ['reading','listening']);
             $table->integer('start_char_index')->nullable();
             $table->integer('end_char_index')->nullable();
-            $table->decimal('start_time_seconds', 8, 3)->nullable();
-            $table->decimal('end_time_seconds', 8, 3)->nullable();
             $table->timestamps();
 
             $table->foreign('breakdown_id')->references('id')->on('question_breakdowns')->cascadeOnDelete();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -14,5 +14,6 @@ class DatabaseSeeder extends Seeder
     public function run(): void
     {
         $this->call(UserSeeder::class);
+        $this->call(CategorySeeder::class);
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -10,6 +10,7 @@ use App\Http\Controllers\VocabularyController;
 use App\Http\Controllers\ClassController;
 use App\Http\Controllers\ClassEnrollmentController;
 use App\Http\Controllers\ClassInvitationController;
+use App\Http\Controllers\ReadingTestQuestionController;
 
 Route::get('/health', fn() => response()->json(['ok' => true, 'time' => time()]));
 
@@ -81,7 +82,7 @@ Route::middleware('auth:sanctum')
         });
     });
 
-Route::middleware(['auth:sanctum'])
+Route::middleware('auth:sanctum')
     ->prefix('invitations')
     ->group(function () {
         Route::get('/', [ClassInvitationController::class, 'index']);
@@ -91,3 +92,18 @@ Route::middleware(['auth:sanctum'])
             Route::delete('/delete/{id}', [ClassInvitationController::class, 'destroy'])->middleware('role:admin,teacher');
         });
     });
+
+Route::middleware('auth:sanctum')->group(function () {
+    Route::prefix('reading')
+        ->group(function () {
+            Route::get('/tests', [ReadingTestQuestionController::class, 'index']);
+            Route::get('/tests/{id}', [ReadingTestQuestionController::class, 'show']);
+            Route::middleware(['role:admin,teacher'])->group(function () {
+                Route::post('/create', [ReadingTestQuestionController::class, 'store']);
+                Route::patch('/update/{id}', [ReadingTestQuestionController::class, 'update']);
+                Route::delete('/delete/passage/{passageId}', [ReadingTestQuestionController::class, 'deletePassage']);
+                Route::delete('/delete/question/{questionId}', [ReadingTestQuestionController::class, 'deleteQuestion']);
+                Route::delete('/delete/{id}', [ReadingTestQuestionController::class, 'destroy']);
+            });
+        });
+});


### PR DESCRIPTION
## 📌 Description

This PR introduces a new **Reading Test** feature by adding a dedicated controller and centralized validation logic.  
The implementation provides endpoints for creating reading tests, passages, question groups, and related entities.

### Key Changes:
- Added `ReadingTestQuestionController` to manage reading test operations
- Updated `ValidationHelper` with `validateReadingTestRequest($request)` for centralized validation
- Modified models (`HighlightSegment`, `QuestionGroup`, `QuestionOption`, `Test`, `TestQuestion`) to support reading test structure
- Added/modified migrations for `test_system` and `question_breakdown`
- Updated `DatabaseSeeder`
- Registered new routes in `routes/api.php`

---

## ✅ To-Do List

- [x] Create `ReadingTestQuestionController`  
- [x] Implement `validateReadingTestRequest` in `ValidationHelper`  
- [x] Update related models and migrations  
- [x] Add seeder updates
- [x] Register API routes for reading test  

---

## 🎯 Goal

Provide a clear and maintainable structure for handling **Reading Test** questions while ensuring validation rules are centralized and reusable.

---

### ✅ Checklist Before Merge

- [x] Endpoints tested and working as expected  
- [x] Validation rules are centralized in `ValidationHelper`  
- [x] Code follows Laravel best practices  
- [x] Database migrations run successfully  
- [x] Seeder runs without errors  

---

### 🔗 Related Issue

Closes #20 
