### PR TITLE
refactor(auth): migrate authentication from Sanctum cookie-based to token-based

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -10,7 +10,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(web: __DIR__ . '/../routes/web.php', api: __DIR__ . '/../routes/api.php', commands: __DIR__ . '/../routes/console.php', health: '/up')
     ->withMiddleware(function (Middleware $middleware): void {
-        $middleware->statefulApi();
+        // $middleware->statefulApi();
         $middleware->alias([
             'role' => \App\Http\Middleware\CheckRole::class,
         ]);

--- a/database/migrations/2025_07_11_085559_create_personal_access_tokens_table.php
+++ b/database/migrations/2025_07_11_085559_create_personal_access_tokens_table.php
@@ -12,8 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
-            $table->id();
-            $table->morphs('tokenable');
+            $table->id();   
+            $table->uuid('tokenable_id');
+            $table->string('tokenable_type');
             $table->text('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,5 +38,3 @@ Route::get('/', function () {
 Route::get('/api/test', function (Request $request) {
     return response()->json(['message' => 'API is working!']);
 });
-
-Route::get('/sanctum/csrf-cookie', [AuthController::class, 'sanctum']);

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -21,29 +21,8 @@
                     "Auth"
                 ],
                 "summary": "Register a new user",
-                "description": "Registers a user and logs them in",
+                "description": "Registers a user and returns an access token",
                 "operationId": "d764dd091cc4494ae0baf360b03319f3",
-                "parameters": [
-                    {
-                        "name": "X-XSRF-TOKEN",
-                        "in": "header",
-                        "description": "CSRF token for session-based auth (Sanctum)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Referer",
-                        "in": "header",
-                        "description": "Referring URL Frontend for CSRF protection",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "example": "http://localhost:3000"
-                        }
-                    }
-                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -89,7 +68,11 @@
                                     "properties": {
                                         "message": {
                                             "type": "string",
-                                            "example": "Registered & Logged in successfully"
+                                            "example": "Registered successfully"
+                                        },
+                                        "token": {
+                                            "type": "string",
+                                            "example": "1|abcdef1234567890"
                                         }
                                     },
                                     "type": "object"
@@ -112,29 +95,8 @@
                     "Auth"
                 ],
                 "summary": "Login user",
-                "description": "Authenticates a user using email and password. Requires X-XSRF-TOKEN header if using Sanctum with session-based auth.",
+                "description": "Authenticates a user and returns an access token",
                 "operationId": "8dcb70df1020986038d098cc08d05dae",
-                "parameters": [
-                    {
-                        "name": "X-XSRF-TOKEN",
-                        "in": "header",
-                        "description": "CSRF token for session-based auth (Sanctum)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Referer",
-                        "in": "header",
-                        "description": "Referring URL Frontend for CSRF protection",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "example": "http://localhost:3000"
-                        }
-                    }
-                ],
                 "requestBody": {
                     "required": true,
                     "content": {
@@ -171,6 +133,10 @@
                                         "message": {
                                             "type": "string",
                                             "example": "Logged in successfully"
+                                        },
+                                        "token": {
+                                            "type": "string",
+                                            "example": "1|abcdef1234567890"
                                         }
                                     },
                                     "type": "object"
@@ -196,29 +162,8 @@
                     "Auth"
                 ],
                 "summary": "Logout the current user",
-                "description": "Invalidates the session and logs out the user. Requires X-XSRF-TOKEN header if using session-based Sanctum.",
+                "description": "Revokes the user's current access token",
                 "operationId": "69281b12abb272c76871f19cb17ca563",
-                "parameters": [
-                    {
-                        "name": "X-XSRF-TOKEN",
-                        "in": "header",
-                        "description": "CSRF token for session-based auth (Sanctum)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Referer",
-                        "in": "header",
-                        "description": "Referring URL Frontend for CSRF protection",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "example": "http://localhost:3000"
-                        }
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Logout successful",
@@ -245,7 +190,7 @@
                 },
                 "security": [
                     {
-                        "sanctum": []
+                        "bearerAuth": []
                     }
                 ]
             }
@@ -256,29 +201,8 @@
                     "Auth"
                 ],
                 "summary": "Get current authenticated user",
-                "description": "Returns the authenticated user's profile data. Requires CSRF token in session-based Sanctum.",
+                "description": "Returns the authenticated user's profile data",
                 "operationId": "b9abb1a7a74670a19c215c2c133f14d8",
-                "parameters": [
-                    {
-                        "name": "X-XSRF-TOKEN",
-                        "in": "header",
-                        "description": "CSRF token for session-based auth (Sanctum)",
-                        "required": false,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "Referer",
-                        "in": "header",
-                        "description": "Referring URL Frontend for CSRF protection",
-                        "required": false,
-                        "schema": {
-                            "type": "string",
-                            "example": "http://localhost:3000"
-                        }
-                    }
-                ],
                 "responses": {
                     "200": {
                         "description": "Authenticated user data",
@@ -301,14 +225,6 @@
                                         "role": {
                                             "type": "string",
                                             "example": "user"
-                                        },
-                                        "avatar": {
-                                            "type": "string",
-                                            "example": "https://example.com/avatar.jpg"
-                                        },
-                                        "bio": {
-                                            "type": "string",
-                                            "example": "Frontend Developer"
                                         }
                                     },
                                     "type": "object"
@@ -322,33 +238,9 @@
                 },
                 "security": [
                     {
-                        "sanctum": []
+                        "bearerAuth": []
                     }
                 ]
-            }
-        },
-        "/sanctum/csrf-cookie": {
-            "get": {
-                "tags": [
-                    "Auth"
-                ],
-                "summary": "Get CSRF token cookie for Sanctum",
-                "description": "This endpoint sets the XSRF-TOKEN cookie required for CSRF protection in session-based auth. Usually called before login.",
-                "operationId": "d5484dc25fb583625272d29e50a62548",
-                "responses": {
-                    "204": {
-                        "description": "CSRF cookie set successfully",
-                        "headers": {
-                            "Set-Cookie": {
-                                "description": "XSRF-TOKEN and/or session cookie",
-                                "schema": {
-                                    "type": "string",
-                                    "example": "XSRF-TOKEN=abc123; Path=/; Secure; HttpOnly; SameSite=Lax"
-                                }
-                            }
-                        }
-                    }
-                }
             }
         },
         "/api/classes": {


### PR DESCRIPTION
### 📌 Description

This PR refactors the authentication mechanism from **Sanctum cookie-based with CSRF protection** to **Sanctum token-based authentication** (personal access tokens / API tokens).  

The goal is to simplify frontend–backend integration (especially with Next.js or mobile apps) by removing CSRF and cookie dependencies, enabling **stateless API communication** through the `Authorization` header.

---

### ✅ Key Changes

#### 🔐 Authentication Flow
- Updated **login endpoint** to return a valid Sanctum token upon successful authentication.
- Configured **authentication middleware** and guards to validate tokens instead of relying on cookies.
- Removed CSRF cookie routes and references, as they are no longer needed.

#### 📡 Frontend Integration
- Updated integration to use:  
  `Authorization: Bearer <token>`  
  for all protected API requests.
- Simplified API calls by removing cookie/session handling.

#### 🚪 Logout & Token Revocation
- Implemented **logout endpoint** that properly revokes the current token.
- Ensured revoked tokens cannot be reused for subsequent requests.

---

## ✅ To-Do List

- [x] Replace cookie-based Sanctum authentication with token-based approach  
- [x] Update login endpoint to issue tokens  
- [x] Configure API routes to use token guards  
- [x] Remove CSRF cookie routes and references  
- [x] Implement secure logout via token revocation  
- [x] Verify frontend authentication using `Authorization` header  

---

## 🎯 Goal

- Provide a **stateless authentication** mechanism using Sanctum tokens.  
- Improve compatibility with **SPAs, mobile apps, and third-party clients**.  
- Reduce maintenance overhead by removing CSRF & cookie handling.  

---

### ✅ Checklist Before Merge

- [x] Login returns a valid Sanctum token  
- [x] Protected API routes require `Authorization` header  
- [x] CSRF cookie routes are removed  
- [x] Logout revokes active token properly  
- [x] Existing features continue to work with token-based flow  

---

### 🔗 Related Issue

Closes #25 
